### PR TITLE
fix(Java): correct getFullRevisionCovered to getIsFullRevisionCovered

### DIFF
--- a/pdftools_sdk/Java/SignaturesValidate/lib/src/main/java/PdfToolsSignaturesValidate/PdfToolsSignaturesValidate.java
+++ b/pdftools_sdk/Java/SignaturesValidate/lib/src/main/java/PdfToolsSignaturesValidate/PdfToolsSignaturesValidate.java
@@ -174,7 +174,16 @@ public class PdfToolsSignaturesValidate
                     System.out.println("Unable to validate document Revision: " + ex.getMessage());
                 }
 
-                printContent(result.getSignatureContent(), result.getSignatureField().getFullRevisionCovered());
+                Boolean isFullRevisionCovered = null;
+                try
+                {
+                    isFullRevisionCovered = result.getSignatureField().getIsFullRevisionCovered();
+                }
+                catch (Exception ex)
+                {
+                    System.out.println("Unable to determine full revision coverage: " + ex.getMessage());
+                }
+                printContent(result.getSignatureContent(), isFullRevisionCovered);
                 System.out.println();
             });
 


### PR DESCRIPTION
## Summary

- Fixes `SignaturesValidate.java` line 177: `getFullRevisionCovered()` → `getIsFullRevisionCovered()`
- `getFullRevisionCovered()` does not exist on `SignedSignatureField` — the sample fails to compile
- `getIsFullRevisionCovered()` throws a checked `CorruptException`, so added try-catch wrapping (matches the pattern used for `getRevision().getIsLatest()` just above)

## Verification

- `mvn compile` ✅
- Runtime test with `InvoiceSigned.pdf` ✅

The C# version already uses the correct property name (`IsFullRevisionCovered`).

Found during verification of documentation-portal PR [#960](https://github.com/pdf-tools/documentation-portal/pull/960).