### PR TITLE
chore: added LICENSE and README files for product-specific and langua…

### DIFF
--- a/pdftools-sdk-examples-c/LICENSE
+++ b/pdftools-sdk-examples-c/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 PDF Tools AG
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pdftools-sdk-examples-c/LICENSE.ADOBE
+++ b/pdftools-sdk-examples-c/LICENSE.ADOBE
@@ -1,0 +1,16 @@
+This repository contains third-party image assets licensed from Adobe Stock.
+
+The Adobe Stock images identified in this repository are licensed under the
+Adobe Stock Standard License (royalty-free, perpetual, non-exclusive)
+and are subject to Adobe’s licensing terms.
+
+These Adobe Stock assets are NOT covered by the main repository license.
+
+Redistribution, extraction, reuse, or sublicensing of these images
+as standalone files is not permitted.
+
+All rights remain with the respective copyright holders
+and Adobe Stock contributors.
+
+For license documentation and proof of purchase,
+please contact PDF Tools AG.

--- a/pdftools-sdk-examples-c/LICENSE.CC-BY-NC
+++ b/pdftools-sdk-examples-c/LICENSE.CC-BY-NC
@@ -1,0 +1,144 @@
+Creative Commons Attribution-NonCommercial 4.0 International
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution-NonCommercial 4.0 International Public License ("Public
+License"). To the extent this Public License may be interpreted as a
+contract, You are granted the Licensed Rights in consideration of Your
+acceptance of these terms and conditions, and the Licensor grants You
+such rights in consideration of benefits the Licensor receives from
+making the Licensed Material available under these terms and
+conditions.
+
+Section 1 -- Definitions.
+
+a. Adapted Material means material subject to Copyright and Similar
+Rights that is derived from or based upon the Licensed Material
+and in which the Licensed Material is translated, altered, arranged,
+transformed, or otherwise modified in a manner requiring permission
+under the Copyright and Similar Rights held by the Licensor.
+For purposes of this Public License, where the Licensed Material
+is a musical work, performance, or sound recording, Adapted
+Material is always produced where the Licensed Material is synched
+in timed relation with a moving image.
+
+b. Adapter's License means the license You apply to Your Copyright
+and Similar Rights in Your contributions to Adapted Material
+in accordance with the terms and conditions of this Public License.
+
+c. Copyright and Similar Rights means copyright and/or similar rights
+closely related to copyright including, without limitation,
+performance, broadcast, sound recording, and Sui Generis Database
+Rights, without regard to how the rights are labeled or categorized.
+For purposes of this Public License, the rights specified in
+Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+
+d. Effective Technological Measures means those measures that, in the
+absence of proper authority, may not be circumvented under laws
+fulfilling obligations under Article 11 of the WIPO Copyright
+Treaty adopted on December 20, 1996, and/or similar international
+agreements.
+
+e. Exceptions and Limitations means fair use, fair dealing, and/or any
+other exception or limitation to Copyright and Similar Rights
+that applies to Your use of the Licensed Material.
+
+f. Licensed Material means the artistic or literary work, database,
+or other material to which the Licensor applied this Public License.
+
+g. Licensed Rights means the rights granted to You subject to the
+terms and conditions of this Public License, which are limited to
+all Copyright and Similar Rights that apply to Your use of the
+Licensed Material and that the Licensor has authority to license.
+
+h. Licensor means the individual(s) or entity(ies) granting rights
+under this Public License.
+
+i. NonCommercial means not primarily intended for or directed towards
+commercial advantage or monetary compensation. For purposes of
+this Public License, the exchange of the Licensed Material for
+other material subject to Copyright and Similar Rights by digital
+file-sharing or similar means is NonCommercial provided there is
+no payment of monetary compensation in connection with the exchange.
+
+j. Share means to provide material to the public by any means or
+process that requires permission under the Licensed Rights, such
+as reproduction, public display, public performance, distribution,
+dissemination, communication, or importation, and to make material
+available to the public including in ways that members of the public
+may access the material from a place and at a time individually
+chosen by them.
+
+k. Sui Generis Database Rights means rights other than copyright
+resulting from Directive 96/9/EC of the European Parliament and of
+the Council of 11 March 1996 on the legal protection of databases,
+as amended and/or succeeded, as well as other essentially equivalent
+rights anywhere in the world.
+
+l. You means the individual or entity exercising the Licensed Rights
+under this Public License. Your has a corresponding meaning.
+
+Section 2 -- Scope.
+
+a. License grant.
+1. Subject to the terms and conditions of this Public License,
+the Licensor hereby grants You a worldwide, royalty-free,
+non-sublicensable, non-exclusive, irrevocable license to
+exercise the Licensed Rights in the Licensed Material to:
+
+A. reproduce and Share the Licensed Material, in whole or in
+part, for NonCommercial purposes only; and
+
+B. produce, reproduce, and Share Adapted Material for
+NonCommercial purposes only.
+
+2. Exceptions and Limitations. For the avoidance of doubt,
+where Exceptions and Limitations apply to Your use, this
+Public License does not apply, and You do not need to comply
+with its terms and conditions.
+
+3. Term. The term of this Public License is specified in
+Section 6(a).
+
+4. Media and formats; technical modifications allowed. The
+Licensor authorizes You to exercise the Licensed Rights in
+all media and formats whether now known or hereafter created,
+and to make technical modifications necessary to do so.
+The Licensor waives and/or agrees not to assert any right or
+authority to forbid You from making technical modifications
+necessary to exercise the Licensed Rights, including technical
+modifications necessary to circumvent Effective Technological
+Measures.
+
+5. Downstream recipients.
+
+A. Offer from the Licensor -- Licensed Material. Every
+recipient of the Licensed Material automatically receives
+an offer from the Licensor to exercise the Licensed Rights
+under the terms and conditions of this Public License.
+
+B. No downstream restrictions. You may not offer or impose
+any additional or different terms or conditions on, or
+apply any Effective Technological Measures to, the Licensed
+Material if doing so restricts exercise of the Licensed
+Rights by any recipient of the Licensed Material.
+
+6. No endorsement. Nothing in this Public License constitutes
+or may be construed as permission to assert or imply that
+You are, or that Your use of the Licensed Material is,
+connected with, or sponsored, endorsed, or granted official
+status by, the Licensor or others designated to receive
+attribution as provided in Section 3(a)(1)(A)(i).
+
+[... truncated for brevity ...]
+
+Creative Commons is not a party to its public licenses.
+Notwithstanding, Creative Commons may elect to apply one of its
+public licenses to material it publishes and in those instances
+will be considered the “Licensor.” Except for the limited purpose
+of indicating that material is shared under a Creative Commons
+public license or as otherwise permitted by the Creative Commons
+policies published at creativecommons.org/policies, Creative
+Commons does not authorize the use of the trademark "Creative
+Commons" or any other trademark or logo of Creative Commons
+without its prior written consent.

--- a/pdftools-sdk-examples-c/LICENSE.md
+++ b/pdftools-sdk-examples-c/LICENSE.md
@@ -1,0 +1,69 @@
+# SDK C Samples – Licensing Overview
+
+This repository contains sample source code and various accompanying
+resources that are subject to different licensing terms.
+
+The purpose of this document is to clearly identify the applicable
+licenses for each category of files included in the repository.
+
+No license granted herein applies beyond the specific files or
+components explicitly described in the respective sections below.
+
+## Sample Source Code
+
+Unless otherwise stated, all source code contained in this repository
+is © 2026 PDF Tools AG. Licensed under the MIT License unless noted otherwise.
+
+See [LICENSE](LICENSE) for the full license text.
+
+## Image and Font Licensing
+
+### PDF Tools AG Image Assets
+
+Unless otherwise stated, all images created and owned by PDF Tools AG are licensed under the
+**Creative Commons Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)** license.
+
+This also applies to PDF documents created by PDF Tools AG,
+provided that they do not contain third-party images or other
+third-party licensed content.
+
+See [LICENSE.CC-BY-NC](LICENSE.CC-BY-NC) for the full license text.
+
+### Third-Party Image Assets (Adobe Stock)
+
+Certain image files and PDF documents in this repository are licensed from **Adobe Stock** under a royalty-free, perpetual, non-exclusive license.
+
+#### Image Files
+
+The following image files are licensed from Adobe Stock:
+
+- `coffee.jpg`
+- `connection.jpg`
+- `ideas.tiff`
+- `multipage.tif`
+
+#### PDF Files Containing Adobe Stock Images
+
+The following PDF files contain images licensed from Adobe Stock:
+
+- `Form2None.pdf`
+- `FormAnnotated.pdf`
+- `FormNone.pdf`
+- `InvoiceEncrypted(pwd_pdftools).pdf`
+- `InvoiceNone.pdf`
+
+See [LICENSE.ADOBE](LICENSE.ADOBE) for the full license text.
+
+## ZUGFeRD Data Format
+
+This repository contains example files based on the ZUGFeRD Data Format (Version 1.0),
+published by the Forum elektronische Rechnung Deutschland (FeRD), AWV e.V.
+
+The ZUGFeRD data format is made available free of charge under a license granting
+an irrevocable right to use, develop, and integrate the format into products and services.
+
+Essential patents of FeRD members are explicitly excluded.
+See [ferd-net.de](https://www.ferd-net.de/) for the current specification and license terms.
+
+For the full license terms, see the header comment within the respective XML files
+or consult the official FeRD documentation.

--- a/pdftools-sdk-examples-c/README.md
+++ b/pdftools-sdk-examples-c/README.md
@@ -1,0 +1,37 @@
+# Pdftools SDK C Code Samples
+
+PDF processing code samples for PDF conversion, archiving, merging, digital signatures, validation, and text extraction. Run code samples in C.
+
+**Pdftools SDK** is a high-level PDF library for conversion, optimization, merging, signing, and validation.
+
+## Licensing
+
+**Pdftools SDK** doesn't require a license key for evaluation. Without a license key, the SDK adds a watermark to output files.
+
+To get a trial license key, create a user account at the [Pdftools portal](https://portal.pdf-tools.com/). For more information, refer to [Trial license overview](https://www.pdf-tools.com/docs/licenses/products/pdf-tools-sdk-license/#trial-license-overview).
+
+## Organization of samples
+
+Each folder contains a self-contained sample with:
+- Source code
+- PDF test files
+- A `README.md` explaining what the sample does and how to run it
+
+## Repository structure
+
+```
+/USE_CASE_FOLDER
+    README.md
+    input.pdf
+    SAMPLE_CODE_AND_CONFIG
+```
+
+## Getting started
+
+1. Clone this repository to your local machine:
+    ```bash
+    git clone https://github.com/pdf-tools/pdftools-sdk-examples-c.git
+    cd pdftools-sdk-examples-c
+    ```
+1. Navigate to the sample you want to run.
+1. Follow the instructions in the `README.md` of that folder.

--- a/pdftools-sdk-examples-csharp/LICENSE
+++ b/pdftools-sdk-examples-csharp/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 PDF Tools AG
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pdftools-sdk-examples-csharp/LICENSE.ADOBE
+++ b/pdftools-sdk-examples-csharp/LICENSE.ADOBE
@@ -1,0 +1,16 @@
+This repository contains third-party image assets licensed from Adobe Stock.
+
+The Adobe Stock images identified in this repository are licensed under the
+Adobe Stock Standard License (royalty-free, perpetual, non-exclusive)
+and are subject to Adobe’s licensing terms.
+
+These Adobe Stock assets are NOT covered by the main repository license.
+
+Redistribution, extraction, reuse, or sublicensing of these images
+as standalone files is not permitted.
+
+All rights remain with the respective copyright holders
+and Adobe Stock contributors.
+
+For license documentation and proof of purchase,
+please contact PDF Tools AG.

--- a/pdftools-sdk-examples-csharp/LICENSE.Apache2
+++ b/pdftools-sdk-examples-csharp/LICENSE.Apache2
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 PDF Tools AG
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pdftools-sdk-examples-csharp/LICENSE.CC-BY-NC
+++ b/pdftools-sdk-examples-csharp/LICENSE.CC-BY-NC
@@ -1,0 +1,144 @@
+Creative Commons Attribution-NonCommercial 4.0 International
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution-NonCommercial 4.0 International Public License ("Public
+License"). To the extent this Public License may be interpreted as a
+contract, You are granted the Licensed Rights in consideration of Your
+acceptance of these terms and conditions, and the Licensor grants You
+such rights in consideration of benefits the Licensor receives from
+making the Licensed Material available under these terms and
+conditions.
+
+Section 1 -- Definitions.
+
+a. Adapted Material means material subject to Copyright and Similar
+Rights that is derived from or based upon the Licensed Material
+and in which the Licensed Material is translated, altered, arranged,
+transformed, or otherwise modified in a manner requiring permission
+under the Copyright and Similar Rights held by the Licensor.
+For purposes of this Public License, where the Licensed Material
+is a musical work, performance, or sound recording, Adapted
+Material is always produced where the Licensed Material is synched
+in timed relation with a moving image.
+
+b. Adapter's License means the license You apply to Your Copyright
+and Similar Rights in Your contributions to Adapted Material
+in accordance with the terms and conditions of this Public License.
+
+c. Copyright and Similar Rights means copyright and/or similar rights
+closely related to copyright including, without limitation,
+performance, broadcast, sound recording, and Sui Generis Database
+Rights, without regard to how the rights are labeled or categorized.
+For purposes of this Public License, the rights specified in
+Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+
+d. Effective Technological Measures means those measures that, in the
+absence of proper authority, may not be circumvented under laws
+fulfilling obligations under Article 11 of the WIPO Copyright
+Treaty adopted on December 20, 1996, and/or similar international
+agreements.
+
+e. Exceptions and Limitations means fair use, fair dealing, and/or any
+other exception or limitation to Copyright and Similar Rights
+that applies to Your use of the Licensed Material.
+
+f. Licensed Material means the artistic or literary work, database,
+or other material to which the Licensor applied this Public License.
+
+g. Licensed Rights means the rights granted to You subject to the
+terms and conditions of this Public License, which are limited to
+all Copyright and Similar Rights that apply to Your use of the
+Licensed Material and that the Licensor has authority to license.
+
+h. Licensor means the individual(s) or entity(ies) granting rights
+under this Public License.
+
+i. NonCommercial means not primarily intended for or directed towards
+commercial advantage or monetary compensation. For purposes of
+this Public License, the exchange of the Licensed Material for
+other material subject to Copyright and Similar Rights by digital
+file-sharing or similar means is NonCommercial provided there is
+no payment of monetary compensation in connection with the exchange.
+
+j. Share means to provide material to the public by any means or
+process that requires permission under the Licensed Rights, such
+as reproduction, public display, public performance, distribution,
+dissemination, communication, or importation, and to make material
+available to the public including in ways that members of the public
+may access the material from a place and at a time individually
+chosen by them.
+
+k. Sui Generis Database Rights means rights other than copyright
+resulting from Directive 96/9/EC of the European Parliament and of
+the Council of 11 March 1996 on the legal protection of databases,
+as amended and/or succeeded, as well as other essentially equivalent
+rights anywhere in the world.
+
+l. You means the individual or entity exercising the Licensed Rights
+under this Public License. Your has a corresponding meaning.
+
+Section 2 -- Scope.
+
+a. License grant.
+1. Subject to the terms and conditions of this Public License,
+the Licensor hereby grants You a worldwide, royalty-free,
+non-sublicensable, non-exclusive, irrevocable license to
+exercise the Licensed Rights in the Licensed Material to:
+
+A. reproduce and Share the Licensed Material, in whole or in
+part, for NonCommercial purposes only; and
+
+B. produce, reproduce, and Share Adapted Material for
+NonCommercial purposes only.
+
+2. Exceptions and Limitations. For the avoidance of doubt,
+where Exceptions and Limitations apply to Your use, this
+Public License does not apply, and You do not need to comply
+with its terms and conditions.
+
+3. Term. The term of this Public License is specified in
+Section 6(a).
+
+4. Media and formats; technical modifications allowed. The
+Licensor authorizes You to exercise the Licensed Rights in
+all media and formats whether now known or hereafter created,
+and to make technical modifications necessary to do so.
+The Licensor waives and/or agrees not to assert any right or
+authority to forbid You from making technical modifications
+necessary to exercise the Licensed Rights, including technical
+modifications necessary to circumvent Effective Technological
+Measures.
+
+5. Downstream recipients.
+
+A. Offer from the Licensor -- Licensed Material. Every
+recipient of the Licensed Material automatically receives
+an offer from the Licensor to exercise the Licensed Rights
+under the terms and conditions of this Public License.
+
+B. No downstream restrictions. You may not offer or impose
+any additional or different terms or conditions on, or
+apply any Effective Technological Measures to, the Licensed
+Material if doing so restricts exercise of the Licensed
+Rights by any recipient of the Licensed Material.
+
+6. No endorsement. Nothing in this Public License constitutes
+or may be construed as permission to assert or imply that
+You are, or that Your use of the Licensed Material is,
+connected with, or sponsored, endorsed, or granted official
+status by, the Licensor or others designated to receive
+attribution as provided in Section 3(a)(1)(A)(i).
+
+[... truncated for brevity ...]
+
+Creative Commons is not a party to its public licenses.
+Notwithstanding, Creative Commons may elect to apply one of its
+public licenses to material it publishes and in those instances
+will be considered the “Licensor.” Except for the limited purpose
+of indicating that material is shared under a Creative Commons
+public license or as otherwise permitted by the Creative Commons
+policies published at creativecommons.org/policies, Creative
+Commons does not authorize the use of the trademark "Creative
+Commons" or any other trademark or logo of Creative Commons
+without its prior written consent.

--- a/pdftools-sdk-examples-csharp/LICENSE.md
+++ b/pdftools-sdk-examples-csharp/LICENSE.md
@@ -1,0 +1,98 @@
+# SDK CSharp Samples – Licensing Overview
+
+This repository contains sample source code and various accompanying
+resources that are subject to different licensing terms.
+
+The purpose of this document is to clearly identify the applicable
+licenses for each category of files included in the repository.
+
+No license granted herein applies beyond the specific files or
+components explicitly described in the respective sections below.
+
+## Sample Source Code
+
+Unless otherwise stated, all source code contained in this repository
+is © 2026 PDF Tools AG. Licensed under the MIT License unless noted otherwise.
+
+See [LICENSE](LICENSE) for the full license text.
+
+## Image and Font Licensing
+
+### PDF Tools AG Image Assets
+
+Unless otherwise stated, all images created and owned by PDF Tools AG are licensed under the
+**Creative Commons Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)** license.
+
+This also applies to PDF documents created by PDF Tools AG,
+provided that they do not contain third-party images or other
+third-party licensed content.
+
+See [LICENSE.CC-BY-NC](LICENSE.CC-BY-NC) for the full license text.
+
+### Third-Party Image Assets (Adobe Stock)
+
+Certain image files and PDF documents in this repository are licensed from **Adobe Stock** under a royalty-free, perpetual, non-exclusive license.
+
+#### Image Files
+
+The following image files are licensed from Adobe Stock:
+
+- `coffee.jpg`
+- `connection.jpg`
+- `ideas.tiff`
+- `multipage.tif`
+
+#### PDF Files Containing Adobe Stock Images
+
+The following PDF files contain images licensed from Adobe Stock:
+
+- `butterfly.pdf`
+- `Form2None.pdf`
+- `FormAnnotated.pdf`
+- `FormNone.pdf`
+- `InvoiceEncrypted(pwd_pdftools).pdf`
+- `InvoiceNone.pdf`
+- `InvoiceSigned.pdf`
+- `Invoice_field.pdf`
+
+See [LICENSE.ADOBE](LICENSE.ADOBE) for the full license text.
+
+### Third-Party Fonts
+
+This repository includes the following third-party font files:
+
+- `OpenSans-Semibold.ttf`  
+  Licensed under the Apache License, Version 2.0. See [LICENSE.Apache2](LICENSE.Apache2) for the full license text.
+
+These font files are not covered by the main repository license and remain subject to their respective license terms.
+
+## ZUGFeRD Data Format
+
+This repository contains example files based on the ZUGFeRD Data Format (Version 1.0),
+published by the Forum elektronische Rechnung Deutschland (FeRD), AWV e.V.
+
+The ZUGFeRD data format is made available free of charge under a license granting
+an irrevocable right to use, develop, and integrate the format into products and services.
+
+Essential patents of FeRD members are explicitly excluded.
+See [ferd-net.de](https://www.ferd-net.de/) for the current specification and license terms.
+
+For the full license terms, see the header comment within the respective XML files
+or consult the official FeRD documentation.
+
+## Public Root Certificates
+
+This repository includes the following public X.509 root certificates,
+redistributed in unmodified form for testing and interoperability purposes:
+
+- `swisscom-rootca-4.cer`
+
+These certificates are not covered by the repository's MIT license
+or any other license applicable to this project.
+
+All rights remain with the respective issuing Certificate Authorities:
+
+- Swisscom
+
+The certificates are publicly available from their respective Certificate Authorities
+and may be subject to the terms and conditions defined by those authorities.

--- a/pdftools-sdk-examples-csharp/README.md
+++ b/pdftools-sdk-examples-csharp/README.md
@@ -1,0 +1,37 @@
+# Pdftools SDK .NET Code Samples
+
+PDF processing code samples for PDF conversion, archiving, merging, digital signatures, validation, and text extraction. Run code samples in .NET.
+
+**Pdftools SDK** is a high-level PDF library for conversion, optimization, merging, signing, and validation.
+
+## Licensing
+
+**Pdftools SDK** doesn't require a license key for evaluation. Without a license key, the SDK adds a watermark to output files.
+
+To get a trial license key, create a user account at the [Pdftools portal](https://portal.pdf-tools.com/). For more information, refer to [Trial license overview](https://www.pdf-tools.com/docs/licenses/products/pdf-tools-sdk-license/#trial-license-overview).
+
+## Organization of samples
+
+Each folder contains a self-contained sample with:
+- Source code
+- PDF test files
+- A `README.md` explaining what the sample does and how to run it
+
+## Repository structure
+
+```
+/USE_CASE_FOLDER
+    README.md
+    input.pdf
+    SAMPLE_CODE_AND_CONFIG
+```
+
+## Getting started
+
+1. Clone this repository to your local machine:
+    ```bash
+    git clone https://github.com/pdf-tools/pdftools-sdk-examples-csharp.git
+    cd pdftools-sdk-examples-csharp
+    ```
+1. Navigate to the sample you want to run.
+1. Follow the instructions in the `README.md` of that folder.

--- a/pdftools-sdk-examples-java/LICENSE
+++ b/pdftools-sdk-examples-java/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 PDF Tools AG
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pdftools-sdk-examples-java/LICENSE.ADOBE
+++ b/pdftools-sdk-examples-java/LICENSE.ADOBE
@@ -1,0 +1,16 @@
+This repository contains third-party image assets licensed from Adobe Stock.
+
+The Adobe Stock images identified in this repository are licensed under the
+Adobe Stock Standard License (royalty-free, perpetual, non-exclusive)
+and are subject to Adobe’s licensing terms.
+
+These Adobe Stock assets are NOT covered by the main repository license.
+
+Redistribution, extraction, reuse, or sublicensing of these images
+as standalone files is not permitted.
+
+All rights remain with the respective copyright holders
+and Adobe Stock contributors.
+
+For license documentation and proof of purchase,
+please contact PDF Tools AG.

--- a/pdftools-sdk-examples-java/LICENSE.Apache2
+++ b/pdftools-sdk-examples-java/LICENSE.Apache2
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 PDF Tools AG
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pdftools-sdk-examples-java/LICENSE.CC-BY-NC
+++ b/pdftools-sdk-examples-java/LICENSE.CC-BY-NC
@@ -1,0 +1,144 @@
+Creative Commons Attribution-NonCommercial 4.0 International
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution-NonCommercial 4.0 International Public License ("Public
+License"). To the extent this Public License may be interpreted as a
+contract, You are granted the Licensed Rights in consideration of Your
+acceptance of these terms and conditions, and the Licensor grants You
+such rights in consideration of benefits the Licensor receives from
+making the Licensed Material available under these terms and
+conditions.
+
+Section 1 -- Definitions.
+
+a. Adapted Material means material subject to Copyright and Similar
+Rights that is derived from or based upon the Licensed Material
+and in which the Licensed Material is translated, altered, arranged,
+transformed, or otherwise modified in a manner requiring permission
+under the Copyright and Similar Rights held by the Licensor.
+For purposes of this Public License, where the Licensed Material
+is a musical work, performance, or sound recording, Adapted
+Material is always produced where the Licensed Material is synched
+in timed relation with a moving image.
+
+b. Adapter's License means the license You apply to Your Copyright
+and Similar Rights in Your contributions to Adapted Material
+in accordance with the terms and conditions of this Public License.
+
+c. Copyright and Similar Rights means copyright and/or similar rights
+closely related to copyright including, without limitation,
+performance, broadcast, sound recording, and Sui Generis Database
+Rights, without regard to how the rights are labeled or categorized.
+For purposes of this Public License, the rights specified in
+Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+
+d. Effective Technological Measures means those measures that, in the
+absence of proper authority, may not be circumvented under laws
+fulfilling obligations under Article 11 of the WIPO Copyright
+Treaty adopted on December 20, 1996, and/or similar international
+agreements.
+
+e. Exceptions and Limitations means fair use, fair dealing, and/or any
+other exception or limitation to Copyright and Similar Rights
+that applies to Your use of the Licensed Material.
+
+f. Licensed Material means the artistic or literary work, database,
+or other material to which the Licensor applied this Public License.
+
+g. Licensed Rights means the rights granted to You subject to the
+terms and conditions of this Public License, which are limited to
+all Copyright and Similar Rights that apply to Your use of the
+Licensed Material and that the Licensor has authority to license.
+
+h. Licensor means the individual(s) or entity(ies) granting rights
+under this Public License.
+
+i. NonCommercial means not primarily intended for or directed towards
+commercial advantage or monetary compensation. For purposes of
+this Public License, the exchange of the Licensed Material for
+other material subject to Copyright and Similar Rights by digital
+file-sharing or similar means is NonCommercial provided there is
+no payment of monetary compensation in connection with the exchange.
+
+j. Share means to provide material to the public by any means or
+process that requires permission under the Licensed Rights, such
+as reproduction, public display, public performance, distribution,
+dissemination, communication, or importation, and to make material
+available to the public including in ways that members of the public
+may access the material from a place and at a time individually
+chosen by them.
+
+k. Sui Generis Database Rights means rights other than copyright
+resulting from Directive 96/9/EC of the European Parliament and of
+the Council of 11 March 1996 on the legal protection of databases,
+as amended and/or succeeded, as well as other essentially equivalent
+rights anywhere in the world.
+
+l. You means the individual or entity exercising the Licensed Rights
+under this Public License. Your has a corresponding meaning.
+
+Section 2 -- Scope.
+
+a. License grant.
+1. Subject to the terms and conditions of this Public License,
+the Licensor hereby grants You a worldwide, royalty-free,
+non-sublicensable, non-exclusive, irrevocable license to
+exercise the Licensed Rights in the Licensed Material to:
+
+A. reproduce and Share the Licensed Material, in whole or in
+part, for NonCommercial purposes only; and
+
+B. produce, reproduce, and Share Adapted Material for
+NonCommercial purposes only.
+
+2. Exceptions and Limitations. For the avoidance of doubt,
+where Exceptions and Limitations apply to Your use, this
+Public License does not apply, and You do not need to comply
+with its terms and conditions.
+
+3. Term. The term of this Public License is specified in
+Section 6(a).
+
+4. Media and formats; technical modifications allowed. The
+Licensor authorizes You to exercise the Licensed Rights in
+all media and formats whether now known or hereafter created,
+and to make technical modifications necessary to do so.
+The Licensor waives and/or agrees not to assert any right or
+authority to forbid You from making technical modifications
+necessary to exercise the Licensed Rights, including technical
+modifications necessary to circumvent Effective Technological
+Measures.
+
+5. Downstream recipients.
+
+A. Offer from the Licensor -- Licensed Material. Every
+recipient of the Licensed Material automatically receives
+an offer from the Licensor to exercise the Licensed Rights
+under the terms and conditions of this Public License.
+
+B. No downstream restrictions. You may not offer or impose
+any additional or different terms or conditions on, or
+apply any Effective Technological Measures to, the Licensed
+Material if doing so restricts exercise of the Licensed
+Rights by any recipient of the Licensed Material.
+
+6. No endorsement. Nothing in this Public License constitutes
+or may be construed as permission to assert or imply that
+You are, or that Your use of the Licensed Material is,
+connected with, or sponsored, endorsed, or granted official
+status by, the Licensor or others designated to receive
+attribution as provided in Section 3(a)(1)(A)(i).
+
+[... truncated for brevity ...]
+
+Creative Commons is not a party to its public licenses.
+Notwithstanding, Creative Commons may elect to apply one of its
+public licenses to material it publishes and in those instances
+will be considered the “Licensor.” Except for the limited purpose
+of indicating that material is shared under a Creative Commons
+public license or as otherwise permitted by the Creative Commons
+policies published at creativecommons.org/policies, Creative
+Commons does not authorize the use of the trademark "Creative
+Commons" or any other trademark or logo of Creative Commons
+without its prior written consent.

--- a/pdftools-sdk-examples-java/LICENSE.md
+++ b/pdftools-sdk-examples-java/LICENSE.md
@@ -1,0 +1,99 @@
+# SDK Java Samples – Licensing Overview
+
+This repository contains sample source code and various accompanying
+resources that are subject to different licensing terms.
+
+The purpose of this document is to clearly identify the applicable
+licenses for each category of files included in the repository.
+
+No license granted herein applies beyond the specific files or
+components explicitly described in the respective sections below.
+
+## Sample Source Code
+
+Unless otherwise stated, all source code contained in this repository
+is © 2026 PDF Tools AG. Licensed under the MIT License unless noted otherwise.
+
+See [LICENSE](LICENSE) for the full license text.
+
+## Image and Font Licensing
+
+### PDF Tools AG Image Assets
+
+Unless otherwise stated, all images created and owned by PDF Tools AG are licensed under the
+**Creative Commons Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)** license.
+
+This also applies to PDF documents created by PDF Tools AG,
+provided that they do not contain third-party images or other
+third-party licensed content.
+
+See [LICENSE.CC-BY-NC](LICENSE.CC-BY-NC) for the full license text.
+
+### Third-Party Image Assets (Adobe Stock)
+
+Certain image files and PDF documents in this repository are licensed from **Adobe Stock** under a royalty-free, perpetual, non-exclusive license.
+
+#### Image Files
+
+The following image files are licensed from Adobe Stock:
+
+- `coffee.jpg`
+- `connection.jpg`
+- `ideas.tiff`
+- `multipage.tif`
+
+#### PDF Files Containing Adobe Stock Images
+
+The following PDF files contain images licensed from Adobe Stock:
+
+- `butterfly.pdf`
+- `Form2None.pdf`
+- `FormAnnotated.pdf`
+- `FormNone.pdf`
+- `InvoiceEncrypted(pwd_pdftools).pdf`
+- `InvoiceNone.pdf`
+- `InvoicePDFA_2b.pdf`
+- `InvoiceSigned.pdf`
+- `Invoice_field.pdf`
+
+See [LICENSE.ADOBE](LICENSE.ADOBE) for the full license text.
+
+### Third-Party Fonts
+
+This repository includes the following third-party font files:
+
+- `OpenSans-Semibold.ttf`  
+  Licensed under the Apache License, Version 2.0. See [LICENSE.Apache2](LICENSE.Apache2) for the full license text.
+
+These font files are not covered by the main repository license and remain subject to their respective license terms.
+
+## ZUGFeRD Data Format
+
+This repository contains example files based on the ZUGFeRD Data Format (Version 1.0),
+published by the Forum elektronische Rechnung Deutschland (FeRD), AWV e.V.
+
+The ZUGFeRD data format is made available free of charge under a license granting
+an irrevocable right to use, develop, and integrate the format into products and services.
+
+Essential patents of FeRD members are explicitly excluded.
+See [ferd-net.de](https://www.ferd-net.de/) for the current specification and license terms.
+
+For the full license terms, see the header comment within the respective XML files
+or consult the official FeRD documentation.
+
+## Public Root Certificates
+
+This repository includes the following public X.509 root certificates,
+redistributed in unmodified form for testing and interoperability purposes:
+
+- `swisscom-rootca-4.cer`
+
+These certificates are not covered by the repository's MIT license
+or any other license applicable to this project.
+
+All rights remain with the respective issuing Certificate Authorities:
+
+- Swisscom
+
+The certificates are publicly available from their respective Certificate Authorities
+and may be subject to the terms and conditions defined by those authorities.

--- a/pdftools-sdk-examples-java/README.md
+++ b/pdftools-sdk-examples-java/README.md
@@ -1,0 +1,37 @@
+# Pdftools SDK Java Code Samples
+
+PDF processing code samples for PDF conversion, archiving, merging, digital signatures, validation, and text extraction. Run code samples in Java.
+
+**Pdftools SDK** is a high-level PDF library for conversion, optimization, merging, signing, and validation.
+
+## Licensing
+
+**Pdftools SDK** doesn't require a license key for evaluation. Without a license key, the SDK adds a watermark to output files.
+
+To get a trial license key, create a user account at the [Pdftools portal](https://portal.pdf-tools.com/). For more information, refer to [Trial license overview](https://www.pdf-tools.com/docs/licenses/products/pdf-tools-sdk-license/#trial-license-overview).
+
+## Organization of samples
+
+Each folder contains a self-contained sample with:
+- Source code
+- PDF test files
+- A `README.md` explaining what the sample does and how to run it
+
+## Repository structure
+
+```
+/USE_CASE_FOLDER
+    README.md
+    input.pdf
+    SAMPLE_CODE_AND_CONFIG
+```
+
+## Getting started
+
+1. Clone this repository to your local machine:
+    ```bash
+    git clone https://github.com/pdf-tools/pdftools-sdk-examples-java.git
+    cd pdftools-sdk-examples-java
+    ```
+1. Navigate to the sample you want to run.
+1. Follow the instructions in the `README.md` of that folder.

--- a/pdftools-sdk-examples-python/LICENSE
+++ b/pdftools-sdk-examples-python/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 PDF Tools AG
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pdftools-sdk-examples-python/LICENSE.ADOBE
+++ b/pdftools-sdk-examples-python/LICENSE.ADOBE
@@ -1,0 +1,16 @@
+This repository contains third-party image assets licensed from Adobe Stock.
+
+The Adobe Stock images identified in this repository are licensed under the
+Adobe Stock Standard License (royalty-free, perpetual, non-exclusive)
+and are subject to Adobe’s licensing terms.
+
+These Adobe Stock assets are NOT covered by the main repository license.
+
+Redistribution, extraction, reuse, or sublicensing of these images
+as standalone files is not permitted.
+
+All rights remain with the respective copyright holders
+and Adobe Stock contributors.
+
+For license documentation and proof of purchase,
+please contact PDF Tools AG.

--- a/pdftools-sdk-examples-python/LICENSE.Apache2
+++ b/pdftools-sdk-examples-python/LICENSE.Apache2
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 PDF Tools AG
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pdftools-sdk-examples-python/LICENSE.CC-BY-NC
+++ b/pdftools-sdk-examples-python/LICENSE.CC-BY-NC
@@ -1,0 +1,144 @@
+Creative Commons Attribution-NonCommercial 4.0 International
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution-NonCommercial 4.0 International Public License ("Public
+License"). To the extent this Public License may be interpreted as a
+contract, You are granted the Licensed Rights in consideration of Your
+acceptance of these terms and conditions, and the Licensor grants You
+such rights in consideration of benefits the Licensor receives from
+making the Licensed Material available under these terms and
+conditions.
+
+Section 1 -- Definitions.
+
+a. Adapted Material means material subject to Copyright and Similar
+Rights that is derived from or based upon the Licensed Material
+and in which the Licensed Material is translated, altered, arranged,
+transformed, or otherwise modified in a manner requiring permission
+under the Copyright and Similar Rights held by the Licensor.
+For purposes of this Public License, where the Licensed Material
+is a musical work, performance, or sound recording, Adapted
+Material is always produced where the Licensed Material is synched
+in timed relation with a moving image.
+
+b. Adapter's License means the license You apply to Your Copyright
+and Similar Rights in Your contributions to Adapted Material
+in accordance with the terms and conditions of this Public License.
+
+c. Copyright and Similar Rights means copyright and/or similar rights
+closely related to copyright including, without limitation,
+performance, broadcast, sound recording, and Sui Generis Database
+Rights, without regard to how the rights are labeled or categorized.
+For purposes of this Public License, the rights specified in
+Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+
+d. Effective Technological Measures means those measures that, in the
+absence of proper authority, may not be circumvented under laws
+fulfilling obligations under Article 11 of the WIPO Copyright
+Treaty adopted on December 20, 1996, and/or similar international
+agreements.
+
+e. Exceptions and Limitations means fair use, fair dealing, and/or any
+other exception or limitation to Copyright and Similar Rights
+that applies to Your use of the Licensed Material.
+
+f. Licensed Material means the artistic or literary work, database,
+or other material to which the Licensor applied this Public License.
+
+g. Licensed Rights means the rights granted to You subject to the
+terms and conditions of this Public License, which are limited to
+all Copyright and Similar Rights that apply to Your use of the
+Licensed Material and that the Licensor has authority to license.
+
+h. Licensor means the individual(s) or entity(ies) granting rights
+under this Public License.
+
+i. NonCommercial means not primarily intended for or directed towards
+commercial advantage or monetary compensation. For purposes of
+this Public License, the exchange of the Licensed Material for
+other material subject to Copyright and Similar Rights by digital
+file-sharing or similar means is NonCommercial provided there is
+no payment of monetary compensation in connection with the exchange.
+
+j. Share means to provide material to the public by any means or
+process that requires permission under the Licensed Rights, such
+as reproduction, public display, public performance, distribution,
+dissemination, communication, or importation, and to make material
+available to the public including in ways that members of the public
+may access the material from a place and at a time individually
+chosen by them.
+
+k. Sui Generis Database Rights means rights other than copyright
+resulting from Directive 96/9/EC of the European Parliament and of
+the Council of 11 March 1996 on the legal protection of databases,
+as amended and/or succeeded, as well as other essentially equivalent
+rights anywhere in the world.
+
+l. You means the individual or entity exercising the Licensed Rights
+under this Public License. Your has a corresponding meaning.
+
+Section 2 -- Scope.
+
+a. License grant.
+1. Subject to the terms and conditions of this Public License,
+the Licensor hereby grants You a worldwide, royalty-free,
+non-sublicensable, non-exclusive, irrevocable license to
+exercise the Licensed Rights in the Licensed Material to:
+
+A. reproduce and Share the Licensed Material, in whole or in
+part, for NonCommercial purposes only; and
+
+B. produce, reproduce, and Share Adapted Material for
+NonCommercial purposes only.
+
+2. Exceptions and Limitations. For the avoidance of doubt,
+where Exceptions and Limitations apply to Your use, this
+Public License does not apply, and You do not need to comply
+with its terms and conditions.
+
+3. Term. The term of this Public License is specified in
+Section 6(a).
+
+4. Media and formats; technical modifications allowed. The
+Licensor authorizes You to exercise the Licensed Rights in
+all media and formats whether now known or hereafter created,
+and to make technical modifications necessary to do so.
+The Licensor waives and/or agrees not to assert any right or
+authority to forbid You from making technical modifications
+necessary to exercise the Licensed Rights, including technical
+modifications necessary to circumvent Effective Technological
+Measures.
+
+5. Downstream recipients.
+
+A. Offer from the Licensor -- Licensed Material. Every
+recipient of the Licensed Material automatically receives
+an offer from the Licensor to exercise the Licensed Rights
+under the terms and conditions of this Public License.
+
+B. No downstream restrictions. You may not offer or impose
+any additional or different terms or conditions on, or
+apply any Effective Technological Measures to, the Licensed
+Material if doing so restricts exercise of the Licensed
+Rights by any recipient of the Licensed Material.
+
+6. No endorsement. Nothing in this Public License constitutes
+or may be construed as permission to assert or imply that
+You are, or that Your use of the Licensed Material is,
+connected with, or sponsored, endorsed, or granted official
+status by, the Licensor or others designated to receive
+attribution as provided in Section 3(a)(1)(A)(i).
+
+[... truncated for brevity ...]
+
+Creative Commons is not a party to its public licenses.
+Notwithstanding, Creative Commons may elect to apply one of its
+public licenses to material it publishes and in those instances
+will be considered the “Licensor.” Except for the limited purpose
+of indicating that material is shared under a Creative Commons
+public license or as otherwise permitted by the Creative Commons
+policies published at creativecommons.org/policies, Creative
+Commons does not authorize the use of the trademark "Creative
+Commons" or any other trademark or logo of Creative Commons
+without its prior written consent.

--- a/pdftools-sdk-examples-python/LICENSE.md
+++ b/pdftools-sdk-examples-python/LICENSE.md
@@ -1,0 +1,99 @@
+# SDK Python Samples – Licensing Overview
+
+This repository contains sample source code and various accompanying
+resources that are subject to different licensing terms.
+
+The purpose of this document is to clearly identify the applicable
+licenses for each category of files included in the repository.
+
+No license granted herein applies beyond the specific files or
+components explicitly described in the respective sections below.
+
+## Sample Source Code
+
+Unless otherwise stated, all source code contained in this repository
+is © 2026 PDF Tools AG. Licensed under the MIT License unless noted otherwise.
+
+See [LICENSE](LICENSE) for the full license text.
+
+## Image and Font Licensing
+
+### PDF Tools AG Image Assets
+
+Unless otherwise stated, all images created and owned by PDF Tools AG are licensed under the
+**Creative Commons Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)** license.
+
+This also applies to PDF documents created by PDF Tools AG,
+provided that they do not contain third-party images or other
+third-party licensed content.
+
+See [LICENSE.CC-BY-NC](LICENSE.CC-BY-NC) for the full license text.
+
+### Third-Party Image Assets (Adobe Stock)
+
+Certain image files and PDF documents in this repository are licensed from **Adobe Stock** under a royalty-free, perpetual, non-exclusive license.
+
+#### Image Files
+
+The following image files are licensed from Adobe Stock:
+
+- `butterfly.jpg`
+- `coffee.jpg`
+- `connection.jpg`
+- `ideas.tiff`
+- `multipage.tif`
+
+#### PDF Files Containing Adobe Stock Images
+
+The following PDF files contain images licensed from Adobe Stock:
+
+- `butterfly.pdf`
+- `Form2None.pdf`
+- `FormAnnotated.pdf`
+- `FormNone.pdf`
+- `InvoiceEncrypted(pwd_pdftools).pdf`
+- `InvoiceNone.pdf`
+- `InvoiceSigned.pdf`
+- `Invoice_field.pdf`
+
+See [LICENSE.ADOBE](LICENSE.ADOBE) for the full license text.
+
+### Third-Party Fonts
+
+This repository includes the following third-party font files:
+
+- `OpenSans-Semibold.ttf`  
+  Licensed under the Apache License, Version 2.0. See [LICENSE.Apache2](LICENSE.Apache2) for the full license text.
+
+These font files are not covered by the main repository license and remain subject to their respective license terms.
+
+## ZUGFeRD Data Format
+
+This repository contains example files based on the ZUGFeRD Data Format (Version 1.0),
+published by the Forum elektronische Rechnung Deutschland (FeRD), AWV e.V.
+
+The ZUGFeRD data format is made available free of charge under a license granting
+an irrevocable right to use, develop, and integrate the format into products and services.
+
+Essential patents of FeRD members are explicitly excluded.
+See [ferd-net.de](https://www.ferd-net.de/) for the current specification and license terms.
+
+For the full license terms, see the header comment within the respective XML files
+or consult the official FeRD documentation.
+
+## Public Root Certificates
+
+This repository includes the following public X.509 root certificates,
+redistributed in unmodified form for testing and interoperability purposes:
+
+- `swisscom-rootca-4.cer`
+
+These certificates are not covered by the repository's MIT license
+or any other license applicable to this project.
+
+All rights remain with the respective issuing Certificate Authorities:
+
+- Swisscom
+
+The certificates are publicly available from their respective Certificate Authorities
+and may be subject to the terms and conditions defined by those authorities.

--- a/pdftools-sdk-examples-python/README.md
+++ b/pdftools-sdk-examples-python/README.md
@@ -1,0 +1,37 @@
+# Pdftools SDK Python Code Samples
+
+PDF processing code samples for PDF conversion, archiving, merging, digital signatures, validation, and text extraction. Run code samples in Python.
+
+**Pdftools SDK** is a high-level PDF library for conversion, optimization, merging, signing, and validation.
+
+## Licensing
+
+**Pdftools SDK** doesn't require a license key for evaluation. Without a license key, the SDK adds a watermark to output files.
+
+To get a trial license key, create a user account at the [Pdftools portal](https://portal.pdf-tools.com/). For more information, refer to [Trial license overview](https://www.pdf-tools.com/docs/licenses/products/pdf-tools-sdk-license/#trial-license-overview).
+
+## Organization of samples
+
+Each folder contains a self-contained sample with:
+- Source code
+- PDF test files
+- A `README.md` explaining what the sample does and how to run it
+
+## Repository structure
+
+```
+/USE_CASE_FOLDER
+    README.md
+    input.pdf
+    SAMPLE_CODE_AND_CONFIG
+```
+
+## Getting started
+
+1. Clone this repository to your local machine:
+    ```bash
+    git clone https://github.com/pdf-tools/pdftools-sdk-examples-python.git
+    cd pdftools-sdk-examples-python
+    ```
+1. Navigate to the sample you want to run.
+1. Follow the instructions in the `README.md` of that folder.

--- a/pdftools-sdk-examples-vbnet/LICENSE
+++ b/pdftools-sdk-examples-vbnet/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 PDF Tools AG
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pdftools-sdk-examples-vbnet/LICENSE.ADOBE
+++ b/pdftools-sdk-examples-vbnet/LICENSE.ADOBE
@@ -1,0 +1,16 @@
+This repository contains third-party image assets licensed from Adobe Stock.
+
+The Adobe Stock images identified in this repository are licensed under the
+Adobe Stock Standard License (royalty-free, perpetual, non-exclusive)
+and are subject to Adobe’s licensing terms.
+
+These Adobe Stock assets are NOT covered by the main repository license.
+
+Redistribution, extraction, reuse, or sublicensing of these images
+as standalone files is not permitted.
+
+All rights remain with the respective copyright holders
+and Adobe Stock contributors.
+
+For license documentation and proof of purchase,
+please contact PDF Tools AG.

--- a/pdftools-sdk-examples-vbnet/LICENSE.Apache2
+++ b/pdftools-sdk-examples-vbnet/LICENSE.Apache2
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 PDF Tools AG
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pdftools-sdk-examples-vbnet/LICENSE.CC-BY-NC
+++ b/pdftools-sdk-examples-vbnet/LICENSE.CC-BY-NC
@@ -1,0 +1,144 @@
+Creative Commons Attribution-NonCommercial 4.0 International
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution-NonCommercial 4.0 International Public License ("Public
+License"). To the extent this Public License may be interpreted as a
+contract, You are granted the Licensed Rights in consideration of Your
+acceptance of these terms and conditions, and the Licensor grants You
+such rights in consideration of benefits the Licensor receives from
+making the Licensed Material available under these terms and
+conditions.
+
+Section 1 -- Definitions.
+
+a. Adapted Material means material subject to Copyright and Similar
+Rights that is derived from or based upon the Licensed Material
+and in which the Licensed Material is translated, altered, arranged,
+transformed, or otherwise modified in a manner requiring permission
+under the Copyright and Similar Rights held by the Licensor.
+For purposes of this Public License, where the Licensed Material
+is a musical work, performance, or sound recording, Adapted
+Material is always produced where the Licensed Material is synched
+in timed relation with a moving image.
+
+b. Adapter's License means the license You apply to Your Copyright
+and Similar Rights in Your contributions to Adapted Material
+in accordance with the terms and conditions of this Public License.
+
+c. Copyright and Similar Rights means copyright and/or similar rights
+closely related to copyright including, without limitation,
+performance, broadcast, sound recording, and Sui Generis Database
+Rights, without regard to how the rights are labeled or categorized.
+For purposes of this Public License, the rights specified in
+Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+
+d. Effective Technological Measures means those measures that, in the
+absence of proper authority, may not be circumvented under laws
+fulfilling obligations under Article 11 of the WIPO Copyright
+Treaty adopted on December 20, 1996, and/or similar international
+agreements.
+
+e. Exceptions and Limitations means fair use, fair dealing, and/or any
+other exception or limitation to Copyright and Similar Rights
+that applies to Your use of the Licensed Material.
+
+f. Licensed Material means the artistic or literary work, database,
+or other material to which the Licensor applied this Public License.
+
+g. Licensed Rights means the rights granted to You subject to the
+terms and conditions of this Public License, which are limited to
+all Copyright and Similar Rights that apply to Your use of the
+Licensed Material and that the Licensor has authority to license.
+
+h. Licensor means the individual(s) or entity(ies) granting rights
+under this Public License.
+
+i. NonCommercial means not primarily intended for or directed towards
+commercial advantage or monetary compensation. For purposes of
+this Public License, the exchange of the Licensed Material for
+other material subject to Copyright and Similar Rights by digital
+file-sharing or similar means is NonCommercial provided there is
+no payment of monetary compensation in connection with the exchange.
+
+j. Share means to provide material to the public by any means or
+process that requires permission under the Licensed Rights, such
+as reproduction, public display, public performance, distribution,
+dissemination, communication, or importation, and to make material
+available to the public including in ways that members of the public
+may access the material from a place and at a time individually
+chosen by them.
+
+k. Sui Generis Database Rights means rights other than copyright
+resulting from Directive 96/9/EC of the European Parliament and of
+the Council of 11 March 1996 on the legal protection of databases,
+as amended and/or succeeded, as well as other essentially equivalent
+rights anywhere in the world.
+
+l. You means the individual or entity exercising the Licensed Rights
+under this Public License. Your has a corresponding meaning.
+
+Section 2 -- Scope.
+
+a. License grant.
+1. Subject to the terms and conditions of this Public License,
+the Licensor hereby grants You a worldwide, royalty-free,
+non-sublicensable, non-exclusive, irrevocable license to
+exercise the Licensed Rights in the Licensed Material to:
+
+A. reproduce and Share the Licensed Material, in whole or in
+part, for NonCommercial purposes only; and
+
+B. produce, reproduce, and Share Adapted Material for
+NonCommercial purposes only.
+
+2. Exceptions and Limitations. For the avoidance of doubt,
+where Exceptions and Limitations apply to Your use, this
+Public License does not apply, and You do not need to comply
+with its terms and conditions.
+
+3. Term. The term of this Public License is specified in
+Section 6(a).
+
+4. Media and formats; technical modifications allowed. The
+Licensor authorizes You to exercise the Licensed Rights in
+all media and formats whether now known or hereafter created,
+and to make technical modifications necessary to do so.
+The Licensor waives and/or agrees not to assert any right or
+authority to forbid You from making technical modifications
+necessary to exercise the Licensed Rights, including technical
+modifications necessary to circumvent Effective Technological
+Measures.
+
+5. Downstream recipients.
+
+A. Offer from the Licensor -- Licensed Material. Every
+recipient of the Licensed Material automatically receives
+an offer from the Licensor to exercise the Licensed Rights
+under the terms and conditions of this Public License.
+
+B. No downstream restrictions. You may not offer or impose
+any additional or different terms or conditions on, or
+apply any Effective Technological Measures to, the Licensed
+Material if doing so restricts exercise of the Licensed
+Rights by any recipient of the Licensed Material.
+
+6. No endorsement. Nothing in this Public License constitutes
+or may be construed as permission to assert or imply that
+You are, or that Your use of the Licensed Material is,
+connected with, or sponsored, endorsed, or granted official
+status by, the Licensor or others designated to receive
+attribution as provided in Section 3(a)(1)(A)(i).
+
+[... truncated for brevity ...]
+
+Creative Commons is not a party to its public licenses.
+Notwithstanding, Creative Commons may elect to apply one of its
+public licenses to material it publishes and in those instances
+will be considered the “Licensor.” Except for the limited purpose
+of indicating that material is shared under a Creative Commons
+public license or as otherwise permitted by the Creative Commons
+policies published at creativecommons.org/policies, Creative
+Commons does not authorize the use of the trademark "Creative
+Commons" or any other trademark or logo of Creative Commons
+without its prior written consent.

--- a/pdftools-sdk-examples-vbnet/LICENSE.md
+++ b/pdftools-sdk-examples-vbnet/LICENSE.md
@@ -1,0 +1,97 @@
+# SDK VBNet Samples – Licensing Overview
+
+This repository contains sample source code and various accompanying
+resources that are subject to different licensing terms.
+
+The purpose of this document is to clearly identify the applicable
+licenses for each category of files included in the repository.
+
+No license granted herein applies beyond the specific files or
+components explicitly described in the respective sections below.
+
+## Sample Source Code
+
+Unless otherwise stated, all source code contained in this repository
+is © 2026 PDF Tools AG. Licensed under the MIT License unless noted otherwise.
+
+See [LICENSE](LICENSE) for the full license text.
+
+## Image and Font Licensing
+
+### PDF Tools AG Image Assets
+
+Unless otherwise stated, all images created and owned by PDF Tools AG are licensed under the
+**Creative Commons Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)** license.
+
+This also applies to PDF documents created by PDF Tools AG,
+provided that they do not contain third-party images or other
+third-party licensed content.
+
+See [LICENSE.CC-BY-NC](LICENSE.CC-BY-NC) for the full license text.
+
+### Third-Party Image Assets (Adobe Stock)
+
+Certain image files and PDF documents in this repository are licensed from **Adobe Stock** under a royalty-free, perpetual, non-exclusive license.
+
+#### Image Files
+
+The following image files are licensed from Adobe Stock:
+
+- `coffee.jpg`
+- `connection.jpg`
+- `ideas.tiff`
+- `multipage.tif`
+
+#### PDF Files Containing Adobe Stock Images
+
+The following PDF files contain images licensed from Adobe Stock:
+
+- `butterfly.pdf`
+- `Form2None.pdf`
+- `FormNone.pdf`
+- `InvoiceEncrypted(pwd_pdftools).pdf`
+- `InvoiceNone.pdf`
+- `InvoiceSigned.pdf`
+- `Invoice_field.pdf`
+
+See [LICENSE.ADOBE](LICENSE.ADOBE) for the full license text.
+
+### Third-Party Fonts
+
+This repository includes the following third-party font files:
+
+- `OpenSans-Semibold.ttf`  
+  Licensed under the Apache License, Version 2.0. See [LICENSE.Apache2](LICENSE.Apache2) for the full license text.
+
+These font files are not covered by the main repository license and remain subject to their respective license terms.
+
+## ZUGFeRD Data Format
+
+This repository contains example files based on the ZUGFeRD Data Format (Version 1.0),
+published by the Forum elektronische Rechnung Deutschland (FeRD), AWV e.V.
+
+The ZUGFeRD data format is made available free of charge under a license granting
+an irrevocable right to use, develop, and integrate the format into products and services.
+
+Essential patents of FeRD members are explicitly excluded.
+See [ferd-net.de](https://www.ferd-net.de/) for the current specification and license terms.
+
+For the full license terms, see the header comment within the respective XML files
+or consult the official FeRD documentation.
+
+## Public Root Certificates
+
+This repository includes the following public X.509 root certificates,
+redistributed in unmodified form for testing and interoperability purposes:
+
+- `swisscom-rootca-4.cer`
+
+These certificates are not covered by the repository's MIT license
+or any other license applicable to this project.
+
+All rights remain with the respective issuing Certificate Authorities:
+
+- Swisscom
+
+The certificates are publicly available from their respective Certificate Authorities
+and may be subject to the terms and conditions defined by those authorities.

--- a/pdftools-sdk-examples-vbnet/README.md
+++ b/pdftools-sdk-examples-vbnet/README.md
@@ -1,0 +1,37 @@
+# Pdftools SDK Visual Basic Code Samples
+
+PDF processing code samples for PDF conversion, archiving, merging, digital signatures, validation, and text extraction. Run code samples in Visual Basic.
+
+**Pdftools SDK** is a high-level PDF library for conversion, optimization, merging, signing, and validation.
+
+## Licensing
+
+**Pdftools SDK** doesn't require a license key for evaluation. Without a license key, the SDK adds a watermark to output files.
+
+To get a trial license key, create a user account at the [Pdftools portal](https://portal.pdf-tools.com/). For more information, refer to [Trial license overview](https://www.pdf-tools.com/docs/licenses/products/pdf-tools-sdk-license/#trial-license-overview).
+
+## Organization of samples
+
+Each folder contains a self-contained sample with:
+- Source code
+- PDF test files
+- A `README.md` explaining what the sample does and how to run it
+
+## Repository structure
+
+```
+/USE_CASE_FOLDER
+    README.md
+    input.pdf
+    SAMPLE_CODE_AND_CONFIG
+```
+
+## Getting started
+
+1. Clone this repository to your local machine:
+    ```bash
+    git clone https://github.com/pdf-tools/pdftools-sdk-examples-vbnet.git
+    cd pdftools-sdk-examples-vbnet
+    ```
+1. Navigate to the sample you want to run.
+1. Follow the instructions in the `README.md` of that folder.

--- a/pdftools-toolbox-examples-c/LICENSE
+++ b/pdftools-toolbox-examples-c/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 PDF Tools AG
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pdftools-toolbox-examples-c/LICENSE.ADOBE
+++ b/pdftools-toolbox-examples-c/LICENSE.ADOBE
@@ -1,0 +1,16 @@
+This repository contains third-party image assets licensed from Adobe Stock.
+
+The Adobe Stock images identified in this repository are licensed under the
+Adobe Stock Standard License (royalty-free, perpetual, non-exclusive)
+and are subject to Adobe’s licensing terms.
+
+These Adobe Stock assets are NOT covered by the main repository license.
+
+Redistribution, extraction, reuse, or sublicensing of these images
+as standalone files is not permitted.
+
+All rights remain with the respective copyright holders
+and Adobe Stock contributors.
+
+For license documentation and proof of purchase,
+please contact PDF Tools AG.

--- a/pdftools-toolbox-examples-c/LICENSE.CC-BY-NC
+++ b/pdftools-toolbox-examples-c/LICENSE.CC-BY-NC
@@ -1,0 +1,144 @@
+Creative Commons Attribution-NonCommercial 4.0 International
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution-NonCommercial 4.0 International Public License ("Public
+License"). To the extent this Public License may be interpreted as a
+contract, You are granted the Licensed Rights in consideration of Your
+acceptance of these terms and conditions, and the Licensor grants You
+such rights in consideration of benefits the Licensor receives from
+making the Licensed Material available under these terms and
+conditions.
+
+Section 1 -- Definitions.
+
+a. Adapted Material means material subject to Copyright and Similar
+Rights that is derived from or based upon the Licensed Material
+and in which the Licensed Material is translated, altered, arranged,
+transformed, or otherwise modified in a manner requiring permission
+under the Copyright and Similar Rights held by the Licensor.
+For purposes of this Public License, where the Licensed Material
+is a musical work, performance, or sound recording, Adapted
+Material is always produced where the Licensed Material is synched
+in timed relation with a moving image.
+
+b. Adapter's License means the license You apply to Your Copyright
+and Similar Rights in Your contributions to Adapted Material
+in accordance with the terms and conditions of this Public License.
+
+c. Copyright and Similar Rights means copyright and/or similar rights
+closely related to copyright including, without limitation,
+performance, broadcast, sound recording, and Sui Generis Database
+Rights, without regard to how the rights are labeled or categorized.
+For purposes of this Public License, the rights specified in
+Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+
+d. Effective Technological Measures means those measures that, in the
+absence of proper authority, may not be circumvented under laws
+fulfilling obligations under Article 11 of the WIPO Copyright
+Treaty adopted on December 20, 1996, and/or similar international
+agreements.
+
+e. Exceptions and Limitations means fair use, fair dealing, and/or any
+other exception or limitation to Copyright and Similar Rights
+that applies to Your use of the Licensed Material.
+
+f. Licensed Material means the artistic or literary work, database,
+or other material to which the Licensor applied this Public License.
+
+g. Licensed Rights means the rights granted to You subject to the
+terms and conditions of this Public License, which are limited to
+all Copyright and Similar Rights that apply to Your use of the
+Licensed Material and that the Licensor has authority to license.
+
+h. Licensor means the individual(s) or entity(ies) granting rights
+under this Public License.
+
+i. NonCommercial means not primarily intended for or directed towards
+commercial advantage or monetary compensation. For purposes of
+this Public License, the exchange of the Licensed Material for
+other material subject to Copyright and Similar Rights by digital
+file-sharing or similar means is NonCommercial provided there is
+no payment of monetary compensation in connection with the exchange.
+
+j. Share means to provide material to the public by any means or
+process that requires permission under the Licensed Rights, such
+as reproduction, public display, public performance, distribution,
+dissemination, communication, or importation, and to make material
+available to the public including in ways that members of the public
+may access the material from a place and at a time individually
+chosen by them.
+
+k. Sui Generis Database Rights means rights other than copyright
+resulting from Directive 96/9/EC of the European Parliament and of
+the Council of 11 March 1996 on the legal protection of databases,
+as amended and/or succeeded, as well as other essentially equivalent
+rights anywhere in the world.
+
+l. You means the individual or entity exercising the Licensed Rights
+under this Public License. Your has a corresponding meaning.
+
+Section 2 -- Scope.
+
+a. License grant.
+1. Subject to the terms and conditions of this Public License,
+the Licensor hereby grants You a worldwide, royalty-free,
+non-sublicensable, non-exclusive, irrevocable license to
+exercise the Licensed Rights in the Licensed Material to:
+
+A. reproduce and Share the Licensed Material, in whole or in
+part, for NonCommercial purposes only; and
+
+B. produce, reproduce, and Share Adapted Material for
+NonCommercial purposes only.
+
+2. Exceptions and Limitations. For the avoidance of doubt,
+where Exceptions and Limitations apply to Your use, this
+Public License does not apply, and You do not need to comply
+with its terms and conditions.
+
+3. Term. The term of this Public License is specified in
+Section 6(a).
+
+4. Media and formats; technical modifications allowed. The
+Licensor authorizes You to exercise the Licensed Rights in
+all media and formats whether now known or hereafter created,
+and to make technical modifications necessary to do so.
+The Licensor waives and/or agrees not to assert any right or
+authority to forbid You from making technical modifications
+necessary to exercise the Licensed Rights, including technical
+modifications necessary to circumvent Effective Technological
+Measures.
+
+5. Downstream recipients.
+
+A. Offer from the Licensor -- Licensed Material. Every
+recipient of the Licensed Material automatically receives
+an offer from the Licensor to exercise the Licensed Rights
+under the terms and conditions of this Public License.
+
+B. No downstream restrictions. You may not offer or impose
+any additional or different terms or conditions on, or
+apply any Effective Technological Measures to, the Licensed
+Material if doing so restricts exercise of the Licensed
+Rights by any recipient of the Licensed Material.
+
+6. No endorsement. Nothing in this Public License constitutes
+or may be construed as permission to assert or imply that
+You are, or that Your use of the Licensed Material is,
+connected with, or sponsored, endorsed, or granted official
+status by, the Licensor or others designated to receive
+attribution as provided in Section 3(a)(1)(A)(i).
+
+[... truncated for brevity ...]
+
+Creative Commons is not a party to its public licenses.
+Notwithstanding, Creative Commons may elect to apply one of its
+public licenses to material it publishes and in those instances
+will be considered the “Licensor.” Except for the limited purpose
+of indicating that material is shared under a Creative Commons
+public license or as otherwise permitted by the Creative Commons
+policies published at creativecommons.org/policies, Creative
+Commons does not authorize the use of the trademark "Creative
+Commons" or any other trademark or logo of Creative Commons
+without its prior written consent.

--- a/pdftools-toolbox-examples-c/LICENSE.md
+++ b/pdftools-toolbox-examples-c/LICENSE.md
@@ -1,0 +1,67 @@
+# Toolbox C Samples – Licensing Overview
+
+This repository contains sample source code and various accompanying
+resources that are subject to different licensing terms.
+
+The purpose of this document is to clearly identify the applicable
+licenses for each category of files included in the repository.
+
+No license granted herein applies beyond the specific files or
+components explicitly described in the respective sections below.
+
+## Sample Source Code
+
+Unless otherwise stated, all source code contained in this repository
+is © 2026 PDF Tools AG. Licensed under the MIT License unless noted otherwise.
+
+See [LICENSE](LICENSE) for the full license text.
+
+## Image and Font Licensing
+
+### PDF Tools AG Image Assets
+
+Unless otherwise stated, all images created and owned by PDF Tools AG are licensed under the
+**Creative Commons Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)** license.
+
+This also applies to PDF documents created by PDF Tools AG,
+provided that they do not contain third-party images or other
+third-party licensed content.
+
+See [LICENSE.CC-BY-NC](LICENSE.CC-BY-NC) for the full license text.
+
+### Third-Party Image Assets (Adobe Stock)
+
+Certain image files and PDF documents in this repository are licensed from **Adobe Stock** under a royalty-free, perpetual, non-exclusive license.
+
+#### Image Files
+
+The following image files are licensed from Adobe Stock:
+
+- `bird_bw.tif`
+- `coffee.jpg`
+
+#### PDF Files Containing Adobe Stock Images
+
+The following PDF files contain images licensed from Adobe Stock:
+
+- `BlankNone.pdf`
+- `Form2None.pdf`
+- `FormNone.pdf`
+- `GraphicsNone.pdf`
+- `GraphicsSmallPage.pdf`
+- `ImageCollection.pdf`
+- `InvoiceBrokenSignature.pdf`
+- `InvoiceMetadata.pdf`
+- `InvoiceNone.pdf`
+- `InvoiceSigned.pdf`
+
+See [LICENSE.ADOBE](LICENSE.ADOBE) for the full license text.
+
+### Third-Party Fonts
+
+This repository includes the following third-party font files:
+
+- `free3of9.ttf`  
+  Licensed under the MIT License. See [LICENSE](LICENSE) for the full license text.
+
+These font files are not covered by the main repository license and remain subject to their respective license terms.

--- a/pdftools-toolbox-examples-c/README.md
+++ b/pdftools-toolbox-examples-c/README.md
@@ -1,0 +1,39 @@
+# Toolbox Add-on C Code Samples
+
+PDF processing code samples for creating PDFs from scratch, editing content, extracting information, and managing metadata. Run code samples in C.
+
+**Toolbox add-on** is a low-level PDF library for creating documents from scratch, editing content, extracting information, and managing metadata.
+
+## Licensing
+
+**Toolbox add-on** requires a trial or full license key to run. Without a valid license key, processing fails.
+
+**Important:** Toolbox add-on processing fails without a valid license key.
+
+To get a trial license key, create a user account at the [Pdftools portal](https://portal.pdf-tools.com/). For more information, refer to [Trial license overview](https://www.pdf-tools.com/docs/licenses/products/pdf-tools-sdk-license/#trial-license-overview).
+
+## Organization of samples
+
+Each folder contains a self-contained sample with:
+- Source code
+- PDF test files
+- A `README.md` explaining what the sample does and how to run it
+
+## Repository structure
+
+```
+/USE_CASE_FOLDER
+    README.md
+    input.pdf
+    SAMPLE_CODE_AND_CONFIG
+```
+
+## Getting started
+
+1. Clone this repository to your local machine:
+    ```bash
+    git clone https://github.com/pdf-tools/pdftools-toolbox-examples-c.git
+    cd pdftools-toolbox-examples-c
+    ```
+1. Navigate to the sample you want to run.
+1. Follow the instructions in the `README.md` of that folder.

--- a/pdftools-toolbox-examples-csharp/LICENSE
+++ b/pdftools-toolbox-examples-csharp/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 PDF Tools AG
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pdftools-toolbox-examples-csharp/LICENSE.ADOBE
+++ b/pdftools-toolbox-examples-csharp/LICENSE.ADOBE
@@ -1,0 +1,16 @@
+This repository contains third-party image assets licensed from Adobe Stock.
+
+The Adobe Stock images identified in this repository are licensed under the
+Adobe Stock Standard License (royalty-free, perpetual, non-exclusive)
+and are subject to Adobe’s licensing terms.
+
+These Adobe Stock assets are NOT covered by the main repository license.
+
+Redistribution, extraction, reuse, or sublicensing of these images
+as standalone files is not permitted.
+
+All rights remain with the respective copyright holders
+and Adobe Stock contributors.
+
+For license documentation and proof of purchase,
+please contact PDF Tools AG.

--- a/pdftools-toolbox-examples-csharp/LICENSE.CC-BY-NC
+++ b/pdftools-toolbox-examples-csharp/LICENSE.CC-BY-NC
@@ -1,0 +1,144 @@
+Creative Commons Attribution-NonCommercial 4.0 International
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution-NonCommercial 4.0 International Public License ("Public
+License"). To the extent this Public License may be interpreted as a
+contract, You are granted the Licensed Rights in consideration of Your
+acceptance of these terms and conditions, and the Licensor grants You
+such rights in consideration of benefits the Licensor receives from
+making the Licensed Material available under these terms and
+conditions.
+
+Section 1 -- Definitions.
+
+a. Adapted Material means material subject to Copyright and Similar
+Rights that is derived from or based upon the Licensed Material
+and in which the Licensed Material is translated, altered, arranged,
+transformed, or otherwise modified in a manner requiring permission
+under the Copyright and Similar Rights held by the Licensor.
+For purposes of this Public License, where the Licensed Material
+is a musical work, performance, or sound recording, Adapted
+Material is always produced where the Licensed Material is synched
+in timed relation with a moving image.
+
+b. Adapter's License means the license You apply to Your Copyright
+and Similar Rights in Your contributions to Adapted Material
+in accordance with the terms and conditions of this Public License.
+
+c. Copyright and Similar Rights means copyright and/or similar rights
+closely related to copyright including, without limitation,
+performance, broadcast, sound recording, and Sui Generis Database
+Rights, without regard to how the rights are labeled or categorized.
+For purposes of this Public License, the rights specified in
+Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+
+d. Effective Technological Measures means those measures that, in the
+absence of proper authority, may not be circumvented under laws
+fulfilling obligations under Article 11 of the WIPO Copyright
+Treaty adopted on December 20, 1996, and/or similar international
+agreements.
+
+e. Exceptions and Limitations means fair use, fair dealing, and/or any
+other exception or limitation to Copyright and Similar Rights
+that applies to Your use of the Licensed Material.
+
+f. Licensed Material means the artistic or literary work, database,
+or other material to which the Licensor applied this Public License.
+
+g. Licensed Rights means the rights granted to You subject to the
+terms and conditions of this Public License, which are limited to
+all Copyright and Similar Rights that apply to Your use of the
+Licensed Material and that the Licensor has authority to license.
+
+h. Licensor means the individual(s) or entity(ies) granting rights
+under this Public License.
+
+i. NonCommercial means not primarily intended for or directed towards
+commercial advantage or monetary compensation. For purposes of
+this Public License, the exchange of the Licensed Material for
+other material subject to Copyright and Similar Rights by digital
+file-sharing or similar means is NonCommercial provided there is
+no payment of monetary compensation in connection with the exchange.
+
+j. Share means to provide material to the public by any means or
+process that requires permission under the Licensed Rights, such
+as reproduction, public display, public performance, distribution,
+dissemination, communication, or importation, and to make material
+available to the public including in ways that members of the public
+may access the material from a place and at a time individually
+chosen by them.
+
+k. Sui Generis Database Rights means rights other than copyright
+resulting from Directive 96/9/EC of the European Parliament and of
+the Council of 11 March 1996 on the legal protection of databases,
+as amended and/or succeeded, as well as other essentially equivalent
+rights anywhere in the world.
+
+l. You means the individual or entity exercising the Licensed Rights
+under this Public License. Your has a corresponding meaning.
+
+Section 2 -- Scope.
+
+a. License grant.
+1. Subject to the terms and conditions of this Public License,
+the Licensor hereby grants You a worldwide, royalty-free,
+non-sublicensable, non-exclusive, irrevocable license to
+exercise the Licensed Rights in the Licensed Material to:
+
+A. reproduce and Share the Licensed Material, in whole or in
+part, for NonCommercial purposes only; and
+
+B. produce, reproduce, and Share Adapted Material for
+NonCommercial purposes only.
+
+2. Exceptions and Limitations. For the avoidance of doubt,
+where Exceptions and Limitations apply to Your use, this
+Public License does not apply, and You do not need to comply
+with its terms and conditions.
+
+3. Term. The term of this Public License is specified in
+Section 6(a).
+
+4. Media and formats; technical modifications allowed. The
+Licensor authorizes You to exercise the Licensed Rights in
+all media and formats whether now known or hereafter created,
+and to make technical modifications necessary to do so.
+The Licensor waives and/or agrees not to assert any right or
+authority to forbid You from making technical modifications
+necessary to exercise the Licensed Rights, including technical
+modifications necessary to circumvent Effective Technological
+Measures.
+
+5. Downstream recipients.
+
+A. Offer from the Licensor -- Licensed Material. Every
+recipient of the Licensed Material automatically receives
+an offer from the Licensor to exercise the Licensed Rights
+under the terms and conditions of this Public License.
+
+B. No downstream restrictions. You may not offer or impose
+any additional or different terms or conditions on, or
+apply any Effective Technological Measures to, the Licensed
+Material if doing so restricts exercise of the Licensed
+Rights by any recipient of the Licensed Material.
+
+6. No endorsement. Nothing in this Public License constitutes
+or may be construed as permission to assert or imply that
+You are, or that Your use of the Licensed Material is,
+connected with, or sponsored, endorsed, or granted official
+status by, the Licensor or others designated to receive
+attribution as provided in Section 3(a)(1)(A)(i).
+
+[... truncated for brevity ...]
+
+Creative Commons is not a party to its public licenses.
+Notwithstanding, Creative Commons may elect to apply one of its
+public licenses to material it publishes and in those instances
+will be considered the “Licensor.” Except for the limited purpose
+of indicating that material is shared under a Creative Commons
+public license or as otherwise permitted by the Creative Commons
+policies published at creativecommons.org/policies, Creative
+Commons does not authorize the use of the trademark "Creative
+Commons" or any other trademark or logo of Creative Commons
+without its prior written consent.

--- a/pdftools-toolbox-examples-csharp/LICENSE.md
+++ b/pdftools-toolbox-examples-csharp/LICENSE.md
@@ -1,0 +1,74 @@
+# Toolbox CSharp Samples – Licensing Overview
+
+This repository contains sample source code and various accompanying
+resources that are subject to different licensing terms.
+
+The purpose of this document is to clearly identify the applicable
+licenses for each category of files included in the repository.
+
+No license granted herein applies beyond the specific files or
+components explicitly described in the respective sections below.
+
+## Sample Source Code
+
+Unless otherwise stated, all source code contained in this repository
+is © 2026 PDF Tools AG. Licensed under the MIT License unless noted otherwise.
+
+See [LICENSE](LICENSE) for the full license text.
+
+## Image and Font Licensing
+
+### PDF Tools AG Image Assets
+
+Unless otherwise stated, all images created and owned by PDF Tools AG are licensed under the
+**Creative Commons Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)** license.
+
+This also applies to PDF documents created by PDF Tools AG,
+provided that they do not contain third-party images or other
+third-party licensed content.
+
+See [LICENSE.CC-BY-NC](LICENSE.CC-BY-NC) for the full license text.
+
+### Third-Party Image Assets (Adobe Stock)
+
+Certain image files and PDF documents in this repository are licensed from **Adobe Stock** under a royalty-free, perpetual, non-exclusive license.
+
+#### Image Files
+
+The following image files are licensed from Adobe Stock:
+
+- `bird_bw.tif`
+- `coffee.jpg`
+- `connection.jpg`
+
+#### PDF Files Containing Adobe Stock Images
+
+The following PDF files contain images licensed from Adobe Stock:
+
+- `BlankFilesEmbedded.pdf`
+- `BlankNone.pdf`
+- `butterfly.pdf`
+- `Form2None.pdf`
+- `FormNone.pdf`
+- `GraphicsNone.pdf`
+- `GraphicsSmallPage.pdf`
+- `GraphicsWhiteTextNoTP.pdf`
+- `ImageCollection.pdf`
+- `InvoiceBrokenSignature.pdf`
+- `InvoiceEncrypted(pwd_pdftools).pdf`
+- `InvoiceMetadata.pdf`
+- `InvoiceNone.pdf`
+- `InvoiceSigned.pdf`
+- `MultipageOutlines.pdf`
+- `TaggedPdf.pdf`
+
+See [LICENSE.ADOBE](LICENSE.ADOBE) for the full license text.
+
+### Third-Party Fonts
+
+This repository includes the following third-party font files:
+
+- `free3of9.ttf`  
+  Licensed under the MIT License. See [LICENSE](LICENSE) for the full license text.
+
+These font files are not covered by the main repository license and remain subject to their respective license terms.

--- a/pdftools-toolbox-examples-csharp/README.md
+++ b/pdftools-toolbox-examples-csharp/README.md
@@ -1,0 +1,39 @@
+# Toolbox Add-on .NET Code Samples
+
+PDF processing code samples for creating PDFs from scratch, editing content, extracting information, and managing metadata. Run code samples in .NET.
+
+**Toolbox add-on** is a low-level PDF library for creating documents from scratch, editing content, extracting information, and managing metadata.
+
+## Licensing
+
+**Toolbox add-on** requires a trial or full license key to run. Without a valid license key, processing fails.
+
+**Important:** Toolbox add-on processing fails without a valid license key.
+
+To get a trial license key, create a user account at the [Pdftools portal](https://portal.pdf-tools.com/). For more information, refer to [Trial license overview](https://www.pdf-tools.com/docs/licenses/products/pdf-tools-sdk-license/#trial-license-overview).
+
+## Organization of samples
+
+Each folder contains a self-contained sample with:
+- Source code
+- PDF test files
+- A `README.md` explaining what the sample does and how to run it
+
+## Repository structure
+
+```
+/USE_CASE_FOLDER
+    README.md
+    input.pdf
+    SAMPLE_CODE_AND_CONFIG
+```
+
+## Getting started
+
+1. Clone this repository to your local machine:
+    ```bash
+    git clone https://github.com/pdf-tools/pdftools-toolbox-examples-csharp.git
+    cd pdftools-toolbox-examples-csharp
+    ```
+1. Navigate to the sample you want to run.
+1. Follow the instructions in the `README.md` of that folder.

--- a/pdftools-toolbox-examples-java/LICENSE
+++ b/pdftools-toolbox-examples-java/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 PDF Tools AG
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pdftools-toolbox-examples-java/LICENSE.ADOBE
+++ b/pdftools-toolbox-examples-java/LICENSE.ADOBE
@@ -1,0 +1,16 @@
+This repository contains third-party image assets licensed from Adobe Stock.
+
+The Adobe Stock images identified in this repository are licensed under the
+Adobe Stock Standard License (royalty-free, perpetual, non-exclusive)
+and are subject to Adobe’s licensing terms.
+
+These Adobe Stock assets are NOT covered by the main repository license.
+
+Redistribution, extraction, reuse, or sublicensing of these images
+as standalone files is not permitted.
+
+All rights remain with the respective copyright holders
+and Adobe Stock contributors.
+
+For license documentation and proof of purchase,
+please contact PDF Tools AG.

--- a/pdftools-toolbox-examples-java/LICENSE.CC-BY-NC
+++ b/pdftools-toolbox-examples-java/LICENSE.CC-BY-NC
@@ -1,0 +1,144 @@
+Creative Commons Attribution-NonCommercial 4.0 International
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution-NonCommercial 4.0 International Public License ("Public
+License"). To the extent this Public License may be interpreted as a
+contract, You are granted the Licensed Rights in consideration of Your
+acceptance of these terms and conditions, and the Licensor grants You
+such rights in consideration of benefits the Licensor receives from
+making the Licensed Material available under these terms and
+conditions.
+
+Section 1 -- Definitions.
+
+a. Adapted Material means material subject to Copyright and Similar
+Rights that is derived from or based upon the Licensed Material
+and in which the Licensed Material is translated, altered, arranged,
+transformed, or otherwise modified in a manner requiring permission
+under the Copyright and Similar Rights held by the Licensor.
+For purposes of this Public License, where the Licensed Material
+is a musical work, performance, or sound recording, Adapted
+Material is always produced where the Licensed Material is synched
+in timed relation with a moving image.
+
+b. Adapter's License means the license You apply to Your Copyright
+and Similar Rights in Your contributions to Adapted Material
+in accordance with the terms and conditions of this Public License.
+
+c. Copyright and Similar Rights means copyright and/or similar rights
+closely related to copyright including, without limitation,
+performance, broadcast, sound recording, and Sui Generis Database
+Rights, without regard to how the rights are labeled or categorized.
+For purposes of this Public License, the rights specified in
+Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+
+d. Effective Technological Measures means those measures that, in the
+absence of proper authority, may not be circumvented under laws
+fulfilling obligations under Article 11 of the WIPO Copyright
+Treaty adopted on December 20, 1996, and/or similar international
+agreements.
+
+e. Exceptions and Limitations means fair use, fair dealing, and/or any
+other exception or limitation to Copyright and Similar Rights
+that applies to Your use of the Licensed Material.
+
+f. Licensed Material means the artistic or literary work, database,
+or other material to which the Licensor applied this Public License.
+
+g. Licensed Rights means the rights granted to You subject to the
+terms and conditions of this Public License, which are limited to
+all Copyright and Similar Rights that apply to Your use of the
+Licensed Material and that the Licensor has authority to license.
+
+h. Licensor means the individual(s) or entity(ies) granting rights
+under this Public License.
+
+i. NonCommercial means not primarily intended for or directed towards
+commercial advantage or monetary compensation. For purposes of
+this Public License, the exchange of the Licensed Material for
+other material subject to Copyright and Similar Rights by digital
+file-sharing or similar means is NonCommercial provided there is
+no payment of monetary compensation in connection with the exchange.
+
+j. Share means to provide material to the public by any means or
+process that requires permission under the Licensed Rights, such
+as reproduction, public display, public performance, distribution,
+dissemination, communication, or importation, and to make material
+available to the public including in ways that members of the public
+may access the material from a place and at a time individually
+chosen by them.
+
+k. Sui Generis Database Rights means rights other than copyright
+resulting from Directive 96/9/EC of the European Parliament and of
+the Council of 11 March 1996 on the legal protection of databases,
+as amended and/or succeeded, as well as other essentially equivalent
+rights anywhere in the world.
+
+l. You means the individual or entity exercising the Licensed Rights
+under this Public License. Your has a corresponding meaning.
+
+Section 2 -- Scope.
+
+a. License grant.
+1. Subject to the terms and conditions of this Public License,
+the Licensor hereby grants You a worldwide, royalty-free,
+non-sublicensable, non-exclusive, irrevocable license to
+exercise the Licensed Rights in the Licensed Material to:
+
+A. reproduce and Share the Licensed Material, in whole or in
+part, for NonCommercial purposes only; and
+
+B. produce, reproduce, and Share Adapted Material for
+NonCommercial purposes only.
+
+2. Exceptions and Limitations. For the avoidance of doubt,
+where Exceptions and Limitations apply to Your use, this
+Public License does not apply, and You do not need to comply
+with its terms and conditions.
+
+3. Term. The term of this Public License is specified in
+Section 6(a).
+
+4. Media and formats; technical modifications allowed. The
+Licensor authorizes You to exercise the Licensed Rights in
+all media and formats whether now known or hereafter created,
+and to make technical modifications necessary to do so.
+The Licensor waives and/or agrees not to assert any right or
+authority to forbid You from making technical modifications
+necessary to exercise the Licensed Rights, including technical
+modifications necessary to circumvent Effective Technological
+Measures.
+
+5. Downstream recipients.
+
+A. Offer from the Licensor -- Licensed Material. Every
+recipient of the Licensed Material automatically receives
+an offer from the Licensor to exercise the Licensed Rights
+under the terms and conditions of this Public License.
+
+B. No downstream restrictions. You may not offer or impose
+any additional or different terms or conditions on, or
+apply any Effective Technological Measures to, the Licensed
+Material if doing so restricts exercise of the Licensed
+Rights by any recipient of the Licensed Material.
+
+6. No endorsement. Nothing in this Public License constitutes
+or may be construed as permission to assert or imply that
+You are, or that Your use of the Licensed Material is,
+connected with, or sponsored, endorsed, or granted official
+status by, the Licensor or others designated to receive
+attribution as provided in Section 3(a)(1)(A)(i).
+
+[... truncated for brevity ...]
+
+Creative Commons is not a party to its public licenses.
+Notwithstanding, Creative Commons may elect to apply one of its
+public licenses to material it publishes and in those instances
+will be considered the “Licensor.” Except for the limited purpose
+of indicating that material is shared under a Creative Commons
+public license or as otherwise permitted by the Creative Commons
+policies published at creativecommons.org/policies, Creative
+Commons does not authorize the use of the trademark "Creative
+Commons" or any other trademark or logo of Creative Commons
+without its prior written consent.

--- a/pdftools-toolbox-examples-java/LICENSE.md
+++ b/pdftools-toolbox-examples-java/LICENSE.md
@@ -1,0 +1,74 @@
+# Toolbox Java Samples – Licensing Overview
+
+This repository contains sample source code and various accompanying
+resources that are subject to different licensing terms.
+
+The purpose of this document is to clearly identify the applicable
+licenses for each category of files included in the repository.
+
+No license granted herein applies beyond the specific files or
+components explicitly described in the respective sections below.
+
+## Sample Source Code
+
+Unless otherwise stated, all source code contained in this repository
+is © 2026 PDF Tools AG. Licensed under the MIT License unless noted otherwise.
+
+See [LICENSE](LICENSE) for the full license text.
+
+## Image and Font Licensing
+
+### PDF Tools AG Image Assets
+
+Unless otherwise stated, all images created and owned by PDF Tools AG are licensed under the
+**Creative Commons Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)** license.
+
+This also applies to PDF documents created by PDF Tools AG,
+provided that they do not contain third-party images or other
+third-party licensed content.
+
+See [LICENSE.CC-BY-NC](LICENSE.CC-BY-NC) for the full license text.
+
+### Third-Party Image Assets (Adobe Stock)
+
+Certain image files and PDF documents in this repository are licensed from **Adobe Stock** under a royalty-free, perpetual, non-exclusive license.
+
+#### Image Files
+
+The following image files are licensed from Adobe Stock:
+
+- `bird_bw.tif`
+- `coffee.jpg`
+- `connection.jpg`
+
+#### PDF Files Containing Adobe Stock Images
+
+The following PDF files contain images licensed from Adobe Stock:
+
+- `BlankFilesEmbedded.pdf`
+- `BlankNone.pdf`
+- `butterfly.pdf`
+- `Form2None.pdf`
+- `FormNone.pdf`
+- `GraphicsNone.pdf`
+- `GraphicsSmallPage.pdf`
+- `GraphicsWhiteTextNoTP.pdf`
+- `ImageCollection.pdf`
+- `InvoiceBrokenSignature.pdf`
+- `InvoiceEncrypted(pwd_pdftools).pdf`
+- `InvoiceMetadata.pdf`
+- `InvoiceNone.pdf`
+- `InvoiceSigned.pdf`
+- `MultipageOutlines.pdf`
+- `TaggedPdf.pdf`
+
+See [LICENSE.ADOBE](LICENSE.ADOBE) for the full license text.
+
+### Third-Party Fonts
+
+This repository includes the following third-party font files:
+
+- `free3of9.ttf`  
+  Licensed under the MIT License. See [LICENSE](LICENSE) for the full license text.
+
+These font files are not covered by the main repository license and remain subject to their respective license terms.

--- a/pdftools-toolbox-examples-java/README.md
+++ b/pdftools-toolbox-examples-java/README.md
@@ -1,0 +1,39 @@
+# Toolbox Add-on Java Code Samples
+
+PDF processing code samples for creating PDFs from scratch, editing content, extracting information, and managing metadata. Run code samples in Java.
+
+**Toolbox add-on** is a low-level PDF library for creating documents from scratch, editing content, extracting information, and managing metadata.
+
+## Licensing
+
+**Toolbox add-on** requires a trial or full license key to run. Without a valid license key, processing fails.
+
+**Important:** Toolbox add-on processing fails without a valid license key.
+
+To get a trial license key, create a user account at the [Pdftools portal](https://portal.pdf-tools.com/). For more information, refer to [Trial license overview](https://www.pdf-tools.com/docs/licenses/products/pdf-tools-sdk-license/#trial-license-overview).
+
+## Organization of samples
+
+Each folder contains a self-contained sample with:
+- Source code
+- PDF test files
+- A `README.md` explaining what the sample does and how to run it
+
+## Repository structure
+
+```
+/USE_CASE_FOLDER
+    README.md
+    input.pdf
+    SAMPLE_CODE_AND_CONFIG
+```
+
+## Getting started
+
+1. Clone this repository to your local machine:
+    ```bash
+    git clone https://github.com/pdf-tools/pdftools-toolbox-examples-java.git
+    cd pdftools-toolbox-examples-java
+    ```
+1. Navigate to the sample you want to run.
+1. Follow the instructions in the `README.md` of that folder.

--- a/pdftools-toolbox-examples-java/README.md
+++ b/pdftools-toolbox-examples-java/README.md
@@ -35,5 +35,5 @@ Each folder contains a self-contained sample with:
     git clone https://github.com/pdf-tools/pdftools-toolbox-examples-java.git
     cd pdftools-toolbox-examples-java
     ```
-1. Navigate to the sample you want to run.
+1. Choose a sample you want to run and navigate to its subfolder.
 1. Follow the instructions in the `README.md` of that folder.

--- a/pdftools-toolbox-examples-python/LICENSE
+++ b/pdftools-toolbox-examples-python/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 PDF Tools AG
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pdftools-toolbox-examples-python/LICENSE.ADOBE
+++ b/pdftools-toolbox-examples-python/LICENSE.ADOBE
@@ -1,0 +1,16 @@
+This repository contains third-party image assets licensed from Adobe Stock.
+
+The Adobe Stock images identified in this repository are licensed under the
+Adobe Stock Standard License (royalty-free, perpetual, non-exclusive)
+and are subject to Adobe’s licensing terms.
+
+These Adobe Stock assets are NOT covered by the main repository license.
+
+Redistribution, extraction, reuse, or sublicensing of these images
+as standalone files is not permitted.
+
+All rights remain with the respective copyright holders
+and Adobe Stock contributors.
+
+For license documentation and proof of purchase,
+please contact PDF Tools AG.

--- a/pdftools-toolbox-examples-python/LICENSE.CC-BY-NC
+++ b/pdftools-toolbox-examples-python/LICENSE.CC-BY-NC
@@ -1,0 +1,144 @@
+Creative Commons Attribution-NonCommercial 4.0 International
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution-NonCommercial 4.0 International Public License ("Public
+License"). To the extent this Public License may be interpreted as a
+contract, You are granted the Licensed Rights in consideration of Your
+acceptance of these terms and conditions, and the Licensor grants You
+such rights in consideration of benefits the Licensor receives from
+making the Licensed Material available under these terms and
+conditions.
+
+Section 1 -- Definitions.
+
+a. Adapted Material means material subject to Copyright and Similar
+Rights that is derived from or based upon the Licensed Material
+and in which the Licensed Material is translated, altered, arranged,
+transformed, or otherwise modified in a manner requiring permission
+under the Copyright and Similar Rights held by the Licensor.
+For purposes of this Public License, where the Licensed Material
+is a musical work, performance, or sound recording, Adapted
+Material is always produced where the Licensed Material is synched
+in timed relation with a moving image.
+
+b. Adapter's License means the license You apply to Your Copyright
+and Similar Rights in Your contributions to Adapted Material
+in accordance with the terms and conditions of this Public License.
+
+c. Copyright and Similar Rights means copyright and/or similar rights
+closely related to copyright including, without limitation,
+performance, broadcast, sound recording, and Sui Generis Database
+Rights, without regard to how the rights are labeled or categorized.
+For purposes of this Public License, the rights specified in
+Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+
+d. Effective Technological Measures means those measures that, in the
+absence of proper authority, may not be circumvented under laws
+fulfilling obligations under Article 11 of the WIPO Copyright
+Treaty adopted on December 20, 1996, and/or similar international
+agreements.
+
+e. Exceptions and Limitations means fair use, fair dealing, and/or any
+other exception or limitation to Copyright and Similar Rights
+that applies to Your use of the Licensed Material.
+
+f. Licensed Material means the artistic or literary work, database,
+or other material to which the Licensor applied this Public License.
+
+g. Licensed Rights means the rights granted to You subject to the
+terms and conditions of this Public License, which are limited to
+all Copyright and Similar Rights that apply to Your use of the
+Licensed Material and that the Licensor has authority to license.
+
+h. Licensor means the individual(s) or entity(ies) granting rights
+under this Public License.
+
+i. NonCommercial means not primarily intended for or directed towards
+commercial advantage or monetary compensation. For purposes of
+this Public License, the exchange of the Licensed Material for
+other material subject to Copyright and Similar Rights by digital
+file-sharing or similar means is NonCommercial provided there is
+no payment of monetary compensation in connection with the exchange.
+
+j. Share means to provide material to the public by any means or
+process that requires permission under the Licensed Rights, such
+as reproduction, public display, public performance, distribution,
+dissemination, communication, or importation, and to make material
+available to the public including in ways that members of the public
+may access the material from a place and at a time individually
+chosen by them.
+
+k. Sui Generis Database Rights means rights other than copyright
+resulting from Directive 96/9/EC of the European Parliament and of
+the Council of 11 March 1996 on the legal protection of databases,
+as amended and/or succeeded, as well as other essentially equivalent
+rights anywhere in the world.
+
+l. You means the individual or entity exercising the Licensed Rights
+under this Public License. Your has a corresponding meaning.
+
+Section 2 -- Scope.
+
+a. License grant.
+1. Subject to the terms and conditions of this Public License,
+the Licensor hereby grants You a worldwide, royalty-free,
+non-sublicensable, non-exclusive, irrevocable license to
+exercise the Licensed Rights in the Licensed Material to:
+
+A. reproduce and Share the Licensed Material, in whole or in
+part, for NonCommercial purposes only; and
+
+B. produce, reproduce, and Share Adapted Material for
+NonCommercial purposes only.
+
+2. Exceptions and Limitations. For the avoidance of doubt,
+where Exceptions and Limitations apply to Your use, this
+Public License does not apply, and You do not need to comply
+with its terms and conditions.
+
+3. Term. The term of this Public License is specified in
+Section 6(a).
+
+4. Media and formats; technical modifications allowed. The
+Licensor authorizes You to exercise the Licensed Rights in
+all media and formats whether now known or hereafter created,
+and to make technical modifications necessary to do so.
+The Licensor waives and/or agrees not to assert any right or
+authority to forbid You from making technical modifications
+necessary to exercise the Licensed Rights, including technical
+modifications necessary to circumvent Effective Technological
+Measures.
+
+5. Downstream recipients.
+
+A. Offer from the Licensor -- Licensed Material. Every
+recipient of the Licensed Material automatically receives
+an offer from the Licensor to exercise the Licensed Rights
+under the terms and conditions of this Public License.
+
+B. No downstream restrictions. You may not offer or impose
+any additional or different terms or conditions on, or
+apply any Effective Technological Measures to, the Licensed
+Material if doing so restricts exercise of the Licensed
+Rights by any recipient of the Licensed Material.
+
+6. No endorsement. Nothing in this Public License constitutes
+or may be construed as permission to assert or imply that
+You are, or that Your use of the Licensed Material is,
+connected with, or sponsored, endorsed, or granted official
+status by, the Licensor or others designated to receive
+attribution as provided in Section 3(a)(1)(A)(i).
+
+[... truncated for brevity ...]
+
+Creative Commons is not a party to its public licenses.
+Notwithstanding, Creative Commons may elect to apply one of its
+public licenses to material it publishes and in those instances
+will be considered the “Licensor.” Except for the limited purpose
+of indicating that material is shared under a Creative Commons
+public license or as otherwise permitted by the Creative Commons
+policies published at creativecommons.org/policies, Creative
+Commons does not authorize the use of the trademark "Creative
+Commons" or any other trademark or logo of Creative Commons
+without its prior written consent.

--- a/pdftools-toolbox-examples-python/LICENSE.md
+++ b/pdftools-toolbox-examples-python/LICENSE.md
@@ -1,0 +1,74 @@
+# Toolbox Python Samples – Licensing Overview
+
+This repository contains sample source code and various accompanying
+resources that are subject to different licensing terms.
+
+The purpose of this document is to clearly identify the applicable
+licenses for each category of files included in the repository.
+
+No license granted herein applies beyond the specific files or
+components explicitly described in the respective sections below.
+
+## Sample Source Code
+
+Unless otherwise stated, all source code contained in this repository
+is © 2026 PDF Tools AG. Licensed under the MIT License unless noted otherwise.
+
+See [LICENSE](LICENSE) for the full license text.
+
+## Image and Font Licensing
+
+### PDF Tools AG Image Assets
+
+Unless otherwise stated, all images created and owned by PDF Tools AG are licensed under the
+**Creative Commons Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)** license.
+
+This also applies to PDF documents created by PDF Tools AG,
+provided that they do not contain third-party images or other
+third-party licensed content.
+
+See [LICENSE.CC-BY-NC](LICENSE.CC-BY-NC) for the full license text.
+
+### Third-Party Image Assets (Adobe Stock)
+
+Certain image files and PDF documents in this repository are licensed from **Adobe Stock** under a royalty-free, perpetual, non-exclusive license.
+
+#### Image Files
+
+The following image files are licensed from Adobe Stock:
+
+- `bird_bw.tif`
+- `coffee.jpg`
+- `connection.jpg`
+
+#### PDF Files Containing Adobe Stock Images
+
+The following PDF files contain images licensed from Adobe Stock:
+
+- `BlankFilesEmbedded.pdf`
+- `BlankNone.pdf`
+- `butterfly.pdf`
+- `Form2None.pdf`
+- `FormNone.pdf`
+- `GraphicsNone.pdf`
+- `GraphicsSmallPage.pdf`
+- `GraphicsWhiteTextNoTP.pdf`
+- `ImageCollection.pdf`
+- `InvoiceBrokenSignature.pdf`
+- `InvoiceEncrypted(pwd_pdftools).pdf`
+- `InvoiceMetadata.pdf`
+- `InvoiceNone.pdf`
+- `InvoiceSigned.pdf`
+- `MultipageOutlines.pdf`
+- `TaggedPdf.pdf`
+
+See [LICENSE.ADOBE](LICENSE.ADOBE) for the full license text.
+
+### Third-Party Fonts
+
+This repository includes the following third-party font files:
+
+- `free3of9.ttf`  
+  Licensed under the MIT License. See [LICENSE](LICENSE) for the full license text.
+
+These font files are not covered by the main repository license and remain subject to their respective license terms.

--- a/pdftools-toolbox-examples-python/README.md
+++ b/pdftools-toolbox-examples-python/README.md
@@ -1,0 +1,39 @@
+# Toolbox Add-on Python Code Samples
+
+PDF processing code samples for creating PDFs from scratch, editing content, extracting information, and managing metadata. Run code samples in Python.
+
+**Toolbox add-on** is a low-level PDF library for creating documents from scratch, editing content, extracting information, and managing metadata.
+
+## Licensing
+
+**Toolbox add-on** requires a trial or full license key to run. Without a valid license key, processing fails.
+
+**Important:** Toolbox add-on processing fails without a valid license key.
+
+To get a trial license key, create a user account at the [Pdftools portal](https://portal.pdf-tools.com/). For more information, refer to [Trial license overview](https://www.pdf-tools.com/docs/licenses/products/pdf-tools-sdk-license/#trial-license-overview).
+
+## Organization of samples
+
+Each folder contains a self-contained sample with:
+- Source code
+- PDF test files
+- A `README.md` explaining what the sample does and how to run it
+
+## Repository structure
+
+```
+/USE_CASE_FOLDER
+    README.md
+    input.pdf
+    SAMPLE_CODE_AND_CONFIG
+```
+
+## Getting started
+
+1. Clone this repository to your local machine:
+    ```bash
+    git clone https://github.com/pdf-tools/pdftools-toolbox-examples-python.git
+    cd pdftools-toolbox-examples-python
+    ```
+1. Navigate to the sample you want to run.
+1. Follow the instructions in the `README.md` of that folder.


### PR DESCRIPTION
After we have agreed on the pdftools-{sdk, toolbox}-examples-{c, csharp, java, python, vbnet} repository structure, I automatically created LICENSE.md and README.md files for each repository. 
* The LICENSE.md files should not have changed in style compared to the LICENSE.md on the main level of the repository (just depending on the specific content of the specific pdftools-{sdk, toolbox}-examples-{c, csharp, java, python, vbnet} repository, it will not list all files or license types.
* Since the README.md files heavily depend on the repository structure, their wording slightly changed. However, I tried to keep the spirit of the original REAMDME.md file as close as possible.